### PR TITLE
New Feature : Scale ETR

### DIFF
--- a/EEPK Editor/EEPK Organiser.csproj
+++ b/EEPK Editor/EEPK Organiser.csproj
@@ -172,6 +172,9 @@
     <Compile Include="Forms\EntitySelector.xaml.cs">
       <DependentUpon>EntitySelector.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Forms\ETR\Scale.xaml.cs">
+      <DependentUpon>Scale.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Forms\LIGHTEMA\LightEmaEditor.xaml.cs">
       <DependentUpon>LightEmaEditor.xaml</DependentUpon>
     </Compile>
@@ -242,6 +245,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Forms\EntitySelector.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Forms\ETR\Scale.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -378,6 +385,7 @@
       <Name>Xv2CoreLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Fody.3.3.2\build\Fody.targets" Condition="Exists('..\packages\Fody.3.3.2\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/EEPK Editor/Forms/ETR/Scale.xaml
+++ b/EEPK Editor/Forms/ETR/Scale.xaml
@@ -1,0 +1,17 @@
+﻿<Window 
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" x:Class="EEPK_Organiser.Forms.ETR.Scale"
+        xmlns:local="clr-namespace:EEPK_Organiser.Forms.ETR"
+        mc:Ignorable="d"
+        Title="Scale" Height="155.42" Width="377.193" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" WindowStyle="ToolWindow" >
+    <Grid>
+        <Button Click="Button_OK_Click" Content="Ok" HorizontalAlignment="Left" Margin="89,91,0,0" VerticalAlignment="Top" Width="75"/>
+        <Button Click="Button_Cancel_Click" Content="Cancel" HorizontalAlignment="Left" Margin="196,91,0,0" VerticalAlignment="Top" Width="75"/>
+        <xctk:SingleUpDown Value="{Binding scaleFactor}" Minimum="-10" Maximum="10" Margin="132,37,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="182" />
+        <Label Content="Scale Factor" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="54,34,0,0" VerticalAlignment="Top" Width="73" Height="23"/>
+
+    </Grid>
+</Window>

--- a/EEPK Editor/Forms/ETR/Scale.xaml.cs
+++ b/EEPK Editor/Forms/ETR/Scale.xaml.cs
@@ -1,0 +1,59 @@
+﻿using ControlzEx;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using Xv2CoreLib.EffectContainer;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace EEPK_Organiser.Forms.ETR
+{
+    /// <summary>
+    /// Interaction logic for ScalePart.xaml
+    /// </summary>
+    public partial class Scale : Window
+    {
+     
+
+
+        private Asset _asset = null;
+
+        public float scaleFactor { get; set; }
+
+      
+
+        public Scale( Asset asset, Window parent = null)
+        {
+            Owner = parent;
+            _asset = asset;
+            DataContext = this;
+            scaleFactor = 1.0f;
+            InitializeComponent();
+          
+        }
+
+        private void Button_OK_Click(object sender, RoutedEventArgs e)
+        {
+         
+            if (scaleFactor != 1.0)
+                _asset.Files[0].EtrFile.ScaleETRParts(scaleFactor);
+         
+
+
+            Close();
+        }
+
+        private void Button_Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/EEPK Editor/MainWindow.xaml
+++ b/EEPK Editor/MainWindow.xaml
@@ -412,9 +412,9 @@
                                 <Label Content="Position Z" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="10,213,0,0" VerticalAlignment="Top" Width="106"/>
                                 <TextBox x:Name="floatTextBox3" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.POSITION_Z, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,217,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120"/>
                                 <Label Content="Scale (Min)" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="10,241,0,0" VerticalAlignment="Top" Width="106"/>
-                                <TextBox x:Name="floatTextBox4" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.SIZE_1, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,245,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120"/>
+                                <TextBox x:Name="floatTextBox4" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.SIZE_1, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,245,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120" IsEnabled="{Binding isNotTBIND, UpdateSourceTrigger=PropertyChanged}"/>
                                 <Label Content="Scale (Max)" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="10,269,0,0" VerticalAlignment="Top" Width="106"/>
-                                <TextBox x:Name="floatTextBox5" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.SIZE_2, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,273,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120"/>
+                                <TextBox x:Name="floatTextBox5" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.SIZE_2, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,273,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120" IsEnabled="{Binding isNotTBIND,  UpdateSourceTrigger=PropertyChanged}"/>
                                 <Label Content="Orientation X (Min)" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="0,297,0,0" VerticalAlignment="Top" Width="116"/>
                                 <TextBox  x:Name="floatTextBox6" Text="{Binding effectContainerFile.SelectedEffect.SelectedEffectPart.F_52, UpdateSourceTrigger=PropertyChanged}" VerticalContentAlignment="Center" HorizontalAlignment="Left" Height="23" Margin="116,301,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="120"/>
                                 <Label Content="Orientation Y (Min)" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="0,325,0,0" VerticalAlignment="Top" Width="116"/>
@@ -655,6 +655,7 @@
                                             <MenuItem Header="Duplicate" Click="TBIND_AssetContainer_Duplicate_Click"/>
                                             <MenuItem Header="Used By?" Click="TBIND_AssetContainer_UsedBy_Click"/>
                                             <Separator/>
+                                            <MenuItem Header="Scale" Click="TBIND_AssetContainer_Scale"/>
                                             <MenuItem Header="Hue Adjustment" Click="TBIND_AssetContainer_Recolor"/>
                                         </ContextMenu>
                                     </DataGrid.ContextMenu>

--- a/EEPK Editor/MainWindow.xaml.cs
+++ b/EEPK Editor/MainWindow.xaml.cs
@@ -80,8 +80,23 @@ namespace EEPK_Organiser
                 return effectContainerFile.CanSave;
             }
         }
+        private bool _isNotTBIND;
+        public bool isNotTBIND
+        {
+            get
+            {
+                return _isNotTBIND;
+            }
 
-
+            set
+            {
+                if (value != this._isNotTBIND)
+                {
+                    _isNotTBIND = value;
+                    NotifyPropertyChanged("isNotTBIND");
+                }
+            }
+        }
         //Effect View
         private bool editModeCancelling = false;
         
@@ -2156,6 +2171,30 @@ namespace EEPK_Organiser
 
         }
 
+        private void TBIND_AssetContainer_Scale(object sender, RoutedEventArgs e)
+        {
+#if !DEBUG
+            try
+#endif
+            {
+                var asset = tbindDataGrid.SelectedItem as Asset;
+
+                if (asset != null)
+                {
+                    Forms.ETR.Scale scaleForm = new Forms.ETR.Scale(asset, this);
+                    scaleForm.ShowDialog();
+                }
+            }
+#if !DEBUG
+            catch (Exception ex)
+            {
+                SaveExceptionLog(ex.ToString());
+                MessageBox.Show(String.Format("An error occured.\n\nDetails: {0}\n\nA log containing more details about the error was saved at \"{1}\".", ex.Message, GeneralInfo.ERROR_LOG_PATH), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+#endif
+
+        }
+
         //Asset Containers: CBIND
         private void CBIND_AssetContainer_AddAsset_Click(object sender, RoutedEventArgs e)
         {
@@ -4145,6 +4184,8 @@ namespace EEPK_Organiser
                 {
                     var selectedEffectPart = listBox.SelectedItem as EffectPart;
 
+                  
+              
                     if (selectedEffectPart != null)
                     {
                         var parentEffect = effectContainerFile.GetEffectAssociatedWithEffectPart(selectedEffectPart);
@@ -4152,10 +4193,10 @@ namespace EEPK_Organiser
                         if (parentEffect != null)
                         {
                             effectDataGrid.SelectedItem = parentEffect;
+                            isNotTBIND = (selectedEffectPart.AssetRef.assetType != AssetType.TBIND);
                         }
                     }
                 }
-
             }
             catch (Exception ex)
             {
@@ -4604,6 +4645,7 @@ namespace EEPK_Organiser
                 MessageBox.Show(String.Format("An error occured.\n\nDetails: {0}\n\nA log containing more details about the error was saved at \"{1}\".", ex.Message, GeneralInfo.ERROR_LOG_PATH), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
-        
+
+      
     }
 }


### PR DESCRIPTION
My first time making a pull request regarding a UI edit
_let alone this is my first time working with WPF UI_
i tried to follow the same style of coding as best as i can.

---------------------------------------------------

ETR Files cannot be scaled using the general EEPK settings (Scale1 and Scale2)
instead, they are composed of multiple **Parts** that each have their own respective scale that represent the final shape in-game
Part scaling is done by scaling the XY points for the **Extrude** component within a Part either by a positive or negative amount 

this change adds a new context menu option "Scale" for TBIND assets, which will scale all the parts with a **ScaleFactor** value
![image](https://user-images.githubusercontent.com/47185022/95143207-22707080-077e-11eb-9681-6f993f0cf4f1.png)


additionally, the Scale1 and Scale2 fields will now be disabled when a user selects a TBIND asset as changing those has no effect and is merely a Placeholder
![image](https://user-images.githubusercontent.com/47185022/95143226-2f8d5f80-077e-11eb-8a88-87c36af5dab3.png)
