### PR TITLE
Add support for CMS id linking to skill install

### DIFF
--- a/LB Mod Installer/Binding/BindingManager.cs
+++ b/LB Mod Installer/Binding/BindingManager.cs
@@ -525,9 +525,6 @@ namespace LB_Mod_Installer.Binding
                                         retID = CUS_File.ConvertToID1(skillId2, skillType);
                                         AddAlias(skillId2.ToString(), id2Alias);
 
-                                        if (!string.IsNullOrWhiteSpace(parentCmsAlias))
-                                            AddAlias(parentCmsEntry.ShortName, parentCmsAlias);
-
                                         assignedSkillIds.Add(skillId2);
                                     }
                                 }

--- a/LB Mod Installer/Binding/BindingManager.cs
+++ b/LB Mod Installer/Binding/BindingManager.cs
@@ -494,29 +494,44 @@ namespace LB_Mod_Installer.Binding
 
                                 CMS_File cmsFile = (CMS_File)install.GetParsedFile<CMS_File>(CMS_PATH);
                                 CUS_File cusFile = (CUS_File)install.GetParsedFile<CUS_File>(CUS_PATH);
-                                CMS_Entry parentCmsEntry = cmsFile.AssignDummyEntryForSkill(cusFile, skillType, assignedSkillIds);
-                                
-                                if(parentCmsEntry == null)
+
+                                CMS_Entry parentCmsEntry;
+
+                                if (!string.IsNullOrWhiteSpace(parentCmsAlias))
+                                {
+                                    parentCmsEntry = cmsFile.AssignCMSEntryForSkill(parentCmsAlias.ToUpper(), cusFile, skillType, assignedSkillIds);
+                                }
+                                else
+                                {
+                                    parentCmsEntry = cmsFile.AssignDummyEntryForSkill(cusFile, skillType, assignedSkillIds);
+                                }
+
+                                if (parentCmsEntry == null)
                                 {
                                     retID = NullTokenInt;
                                     break;
                                 }
-
-                                int skillId2 = cusFile.AssignNewSkillId(parentCmsEntry, skillType, assignedSkillIds);
-
-                                if(skillId2 == -1)
+                                else
                                 {
-                                    retID = NullTokenInt;
-                                    break;
+                                    int skillId2 = cusFile.AssignNewSkillId(parentCmsEntry, skillType, assignedSkillIds);
+
+                                    if (skillId2 == -1)
+                                    {
+                                        retID = NullTokenInt;
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        retID = CUS_File.ConvertToID1(skillId2, skillType);
+                                        AddAlias(skillId2.ToString(), id2Alias);
+
+                                        if (!string.IsNullOrWhiteSpace(parentCmsAlias))
+                                            AddAlias(parentCmsEntry.ShortName, parentCmsAlias);
+
+                                        assignedSkillIds.Add(skillId2);
+                                    }
                                 }
 
-                                retID = CUS_File.ConvertToID1(skillId2, skillType);
-                                AddAlias(skillId2.ToString(), id2Alias);
-
-                                if(!string.IsNullOrWhiteSpace(parentCmsAlias))
-                                    AddAlias(parentCmsEntry.ShortName, parentCmsAlias);
-
-                                assignedSkillIds.Add(skillId2);
                             }
                             break;
                         case Function.Addition:

--- a/LB Mod Installer/Binding/BindingManager.cs
+++ b/LB Mod Installer/Binding/BindingManager.cs
@@ -499,7 +499,7 @@ namespace LB_Mod_Installer.Binding
 
                                 if (!string.IsNullOrWhiteSpace(parentCmsAlias))
                                 {
-                                    parentCmsEntry = cmsFile.AssignCMSEntryForSkill(parentCmsAlias.ToUpper(), cusFile, skillType, assignedSkillIds);
+                                    parentCmsEntry = cmsFile.AssignCMSEntryForSkill(parentCmsAlias, cusFile, skillType, assignedSkillIds);
                                 }
                                 else
                                 {

--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -55,6 +55,7 @@ using Xv2CoreLib.QSL;
 using Xv2CoreLib.QED;
 using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
+using Xv2CoreLib.EEPK;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -628,6 +629,12 @@ namespace LB_Mod_Installer.Installer
                             BDM_File bdmFile = BDM_File.Load(zipManager.GetFileFromArchive(file.FullName));
                             bdmFile.ChangeNeutralSkillId((ushort)id2);
                             fileManager.AddParsedFile(newFilePath, bdmFile);
+                        }
+                        else if (ext == ".eepk" && fileInstance.RenameEEPKContainers)
+                        {
+                            EEPK_File eepkFile = EEPK_File.LoadEepk(zipManager.GetFileFromArchive(file.FullName));
+                            eepkFile.RenameContainersToSkillFolder(folderName);
+                            fileManager.AddParsedFile(newFilePath, eepkFile);
                         }
                         else
                         {
@@ -2557,6 +2564,8 @@ namespace LB_Mod_Installer.Installer
                     return ((TNN_File)data).Write();
                 case ".odf":
                     return ((ODF_File)data).Write();
+                case ".eepk":
+                    return ((EEPK_File)data).SaveToBytes();
                 default:
                     throw new InvalidDataException(String.Format("GetBytesFromParsedFile: The filetype of \"{0}\" is not supported.", path));
             }

--- a/LB Mod Installer/Installer/InstallerXml.cs
+++ b/LB Mod Installer/Installer/InstallerXml.cs
@@ -1063,6 +1063,9 @@ namespace LB_Mod_Installer.Installer
         [YAXAttributeForClass]
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = -1)]
         public string SkillID { get; set; }
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = false)]
+        public bool RenameEEPKContainers { get; set; }
 
 
         public FileType GetFileType()

--- a/Xv2CoreLib/CMS/CMS_File.cs
+++ b/Xv2CoreLib/CMS/CMS_File.cs
@@ -157,6 +157,16 @@ namespace Xv2CoreLib.CMS
             return dummyCmsEntry;
         }
 
+        public CMS_Entry AssignCMSEntryForSkill(string charaCode, CUS.CUS_File cusFile, CUS.CUS_File.SkillType skillType, List<int> assignedIds = null)
+        {
+            CMS_Entry cmsEntry = GetEntryByCharaCode(charaCode.ToUpper());
+
+            if (!cusFile.IsSkillIdRangeUsed(cmsEntry, skillType, assignedIds))
+                return cmsEntry;
+
+            return null;
+        }
+
         public string GetSkillOwner(int skillId2)
         {
             int cmsId = skillId2 / 10;

--- a/Xv2CoreLib/EEPK/EEPK_File.cs
+++ b/Xv2CoreLib/EEPK/EEPK_File.cs
@@ -158,6 +158,32 @@ namespace Xv2CoreLib.EEPK
             return id;
         }
 
+        public void RenameContainersToSkillFolder(string newName)
+        {
+            foreach (AssetContainer container in Assets)
+            {
+                string I_16 = container.I_16.ToString();
+
+                if (I_16 == "PBIND" || I_16 == "CBIND" || I_16 == "TBIND")
+                {
+                    List<string> filesList = container.FILES.ToList();
+
+                    for (int i = 0; i < filesList.Count; i++)
+                    {
+                        string file = filesList[i];
+                        string name = Path.GetFileNameWithoutExtension(file);
+                        string ext1 = Path.GetExtension(file);
+                        string ext2 = Path.GetExtension(Path.GetFileNameWithoutExtension(file));
+                        name = name.Replace(name, newName);
+
+                        string newFileName = string.Format("{0}{1}{2}", name, ext2, ext1);
+
+                        container.FILES[i] = newFileName;
+                    }
+                }
+            }
+        }
+
     }
 
     [Serializable]

--- a/Xv2CoreLib/EEPK/EEPK_File.cs
+++ b/Xv2CoreLib/EEPK/EEPK_File.cs
@@ -164,21 +164,24 @@ namespace Xv2CoreLib.EEPK
             {
                 string I_16 = container.I_16.ToString();
 
-                if (I_16 == "PBIND" || I_16 == "CBIND" || I_16 == "TBIND")
+                if (I_16 == "PBIND" || I_16 == "CBIND" || I_16 == "TBIND" || I_16 == "LIGHT")
                 {
                     List<string> filesList = container.FILES.ToList();
 
                     for (int i = 0; i < filesList.Count; i++)
                     {
                         string file = filesList[i];
-                        string name = Path.GetFileNameWithoutExtension(file);
-                        string ext1 = Path.GetExtension(file);
-                        string ext2 = Path.GetExtension(Path.GetFileNameWithoutExtension(file));
-                        name = name.Replace(name, newName);
+                        if (file != "NULL")
+                        {
+                            string name = Path.GetFileNameWithoutExtension(file);
+                            string ext1 = Path.GetExtension(file);
+                            string ext2 = Path.GetExtension(Path.GetFileNameWithoutExtension(file));
+                            name = name.Replace(name, newName);
 
-                        string newFileName = string.Format("{0}{1}{2}", name, ext2, ext1);
+                            string newFileName = string.Format("{0}{1}{2}", name, ext2, ext1);
 
-                        container.FILES[i] = newFileName;
+                            container.FILES[i] = newFileName;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A pretty useless addition but.

This adds the ability to link a 3 letter character code in the CUS with AutoSkillID like so for example:
`{AutoSkillID=(Ultimate; SKILL_ID2; TST), SetAlias=SKILL_ID1}`

This also adds a function that renames the EEPK containers to the skill folder if in the InstallerXml the following is set
`RenameEEPKContainers="true"`

Example:
```
<File Type="SkillDir" SkillType="Ultimate" SkillID="{GetAlias=SKILL_ID2}" RenameEEPKContainers="true">
	<SourcePath value="SKILL_DIR" />
</File>
```

**USING THIS BOOLEAN REQUIRES THE CONTAINER NAMES IN THE SKILL FOLDER TO BE NNNN_CCC_SSSS JUST LIKE THE OTHER FILES**
![image](https://github.com/LazyBone152/XV2-Tools/assets/51948142/40cce500-2a8d-4d6e-8a9a-0a6f5e3a4ce4)

Due to limitations of the game, one CMS id can only have 10 skills linked to it and the range for the ids should be between 250 and 500. (Correct me if I'm wrong).

Any feedback is appreciated.