### PR TITLE
update IDB parsing for new version

### DIFF
--- a/Xv2CoreLib/IDB/Deserializer.cs
+++ b/Xv2CoreLib/IDB/Deserializer.cs
@@ -155,7 +155,7 @@ namespace Xv2CoreLib.IDB
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
                     if (version >= 2)
                     {
-                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_08));
+                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].HowMsgID));
                         bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_10));
                     }
                     bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));

--- a/Xv2CoreLib/IDB/Deserializer.cs
+++ b/Xv2CoreLib/IDB/Deserializer.cs
@@ -144,18 +144,20 @@ namespace Xv2CoreLib.IDB
 
         private void WriteEntriesNew(int count, int version)
         {
-            // These version checks can definitely be better...
             if (version != 1 && version != 2)
                 throw new InvalidDataException($"IDB: This IDB version is not supported (Version: {version}).");
 
-            if (version == 1)
-            {
                 for (int i = 0; i < count; i++)
                 {
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].ID));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_02));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NameMsgID));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
+                    if (version >= 2)
+                    {
+                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_08));
+                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_10));
+                    }
                     bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_10));
 
@@ -168,6 +170,11 @@ namespace Xv2CoreLib.IDB
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_20));
                     bytes.AddRange(BitConverter.GetBytes((int)idbFile.Entries[i].RaceLock));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_28));
+                    if (version >= 2)
+                    {
+                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_32));
+                        bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_36));
+                    }
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_32));
                     bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_36));
                     bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].I_38));
@@ -183,48 +190,6 @@ namespace Xv2CoreLib.IDB
                     WriteEffectNew(idbFile.Entries[i].Effects[1], version);
                     WriteEffectNew(idbFile.Entries[i].Effects[2], version);
                 }
-            }
-
-            if (version == 2)
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].ID));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_02));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NameMsgID));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_08));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_10));
-                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_10));
-
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_12));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_14));
-
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_12));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_14));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_16));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_20));
-                    bytes.AddRange(BitConverter.GetBytes((int)idbFile.Entries[i].RaceLock));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_28));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_32));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_36));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_32));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_36));
-                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].I_38));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_40));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_42));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_44));
-                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_46));
-
-                    if (idbFile.Entries[i].Effects.Count() != 3)
-                        throw new InvalidDataException(String.Format("Effect entry count mismatch. There must be 3. (ID: {0})", idbFile.Entries[i].Index));
-
-                    WriteEffectNew(idbFile.Entries[i].Effects[0], version);
-                    WriteEffectNew(idbFile.Entries[i].Effects[1], version);
-                    WriteEffectNew(idbFile.Entries[i].Effects[2], version);
-                }
-            }
 
         }
 

--- a/Xv2CoreLib/IDB/Deserializer.cs
+++ b/Xv2CoreLib/IDB/Deserializer.cs
@@ -70,7 +70,8 @@ namespace Xv2CoreLib.IDB
                     WriteEntriesOld(count);
                     break;
                 case 1:
-                    WriteEntriesNew(count);
+                case 2:
+                    WriteEntriesNew(count, idbFile.Version);
                     break;
             }
         }
@@ -141,49 +142,104 @@ namespace Xv2CoreLib.IDB
             bytes.AddRange(BitConverter_Ex.GetBytes(effect.F_156));
         }
 
-        private void WriteEntriesNew(int count)
+        private void WriteEntriesNew(int count, int version)
         {
-            for (int i = 0; i < count; i++)
+            // These version checks can definitely be better...
+            if (version != 1 && version != 2)
+                throw new InvalidDataException($"IDB: This IDB version is not supported (Version: {version}).");
+
+            if (version == 1)
             {
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].ID));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_02));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NameMsgID));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
-                bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_10));
+                for (int i = 0; i < count; i++)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].ID));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_02));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NameMsgID));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_10));
 
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_12));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_14));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_12));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_14));
 
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_12));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_14));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_16));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_20));
-                bytes.AddRange(BitConverter.GetBytes((int)idbFile.Entries[i].RaceLock));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_28));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_32));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_36));
-                bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].I_38));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_40));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_42));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_44));
-                bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_46));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_14));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_20));
+                    bytes.AddRange(BitConverter.GetBytes((int)idbFile.Entries[i].RaceLock));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_28));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_32));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_36));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].I_38));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_40));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_42));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_44));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_46));
 
-                if (idbFile.Entries[i].Effects.Count() != 3)
-                    throw new InvalidDataException(String.Format("Effect entry count mismatch. There must be 3. (ID: {0})", idbFile.Entries[i].Index));
+                    if (idbFile.Entries[i].Effects.Count() != 3)
+                        throw new InvalidDataException(String.Format("Effect entry count mismatch. There must be 3. (ID: {0})", idbFile.Entries[i].Index));
 
-                WriteEffectNew(idbFile.Entries[i].Effects[0]);
-                WriteEffectNew(idbFile.Entries[i].Effects[1]);
-                WriteEffectNew(idbFile.Entries[i].Effects[2]);
+                    WriteEffectNew(idbFile.Entries[i].Effects[0], version);
+                    WriteEffectNew(idbFile.Entries[i].Effects[1], version);
+                    WriteEffectNew(idbFile.Entries[i].Effects[2], version);
+                }
+            }
+
+            if (version == 2)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].ID));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_02));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NameMsgID));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].DescMsgID));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_08));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_10));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].Type));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_10));
+
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_12));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_14));
+
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_14));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_20));
+                    bytes.AddRange(BitConverter.GetBytes((int)idbFile.Entries[i].RaceLock));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_28));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_32));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].NEW_I_36));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_32));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_36));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)idbFile.Entries[i].I_38));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_40));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_42));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_44));
+                    bytes.AddRange(BitConverter.GetBytes(idbFile.Entries[i].I_46));
+
+                    if (idbFile.Entries[i].Effects.Count() != 3)
+                        throw new InvalidDataException(String.Format("Effect entry count mismatch. There must be 3. (ID: {0})", idbFile.Entries[i].Index));
+
+                    WriteEffectNew(idbFile.Entries[i].Effects[0], version);
+                    WriteEffectNew(idbFile.Entries[i].Effects[1], version);
+                    WriteEffectNew(idbFile.Entries[i].Effects[2], version);
+                }
             }
 
         }
 
-        private void WriteEffectNew(IBD_Effect effect)
+        private void WriteEffectNew(IBD_Effect effect, int version)
         {
+            if (version != 1 && version != 2)
+                throw new InvalidDataException($"IDB: This IDB version is not supported (Version: {version}).");
+
             bytes.AddRange(BitConverter.GetBytes(effect.I_00));
             bytes.AddRange(BitConverter.GetBytes(effect.I_04));
             bytes.AddRange(BitConverter.GetBytes(effect.I_08));
+
+            if (version == 2)
+                bytes.AddRange(BitConverter.GetBytes(effect.NEW_I_12));
+
             bytes.AddRange(BitConverter.GetBytes(effect.F_12));
             Assertion.AssertArraySize(effect.F_16, 6, "Effect", "Ability_Values");
             bytes.AddRange(BitConverter_Ex.GetBytes(effect.F_16));

--- a/Xv2CoreLib/IDB/IDB_File.cs
+++ b/Xv2CoreLib/IDB/IDB_File.cs
@@ -43,9 +43,10 @@ namespace Xv2CoreLib.IDB
     {
         [YAXAttributeForClass]
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 1)]
-        public int Version { get; set; } = 1;
+        public int Version { get; set; } = 2;
         //0 = original IDB version (used from 1.00 to 1.17)
         //1 = updated IDB version first used since 1.18
+        //2 = updated IDB version first used since 1.22
 
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "IDB_Entry")]
         public List<IDB_Entry> Entries { get; set; }
@@ -265,7 +266,8 @@ namespace Xv2CoreLib.IDB
     public class IDB_Entry : IInstallable
     {
         public const int OLD_ENTRY_SIZE = 48;
-        public const int NEW_ENTRY_SIZE = 52; //New in 1.18
+        public const int ENTRY_SIZE_V1 = 52; //New in 1.18
+        public const int ENTRY_SIZE_V2 = 64; //New in 1.22
 
         public const string TALISMAN_NAME_MSG = "msg/proper_noun_talisman_info_";
         public const string TALISMAN_DESCRIPTION_MSG = "msg/proper_noun_talisman_name_";
@@ -296,6 +298,12 @@ namespace Xv2CoreLib.IDB
         [YAXAttributeFor("Description")]
         [YAXSerializeAs("MSG_ID")]
         public ushort DescMsgID { get; set; }
+        [YAXAttributeFor("NEW_I_08")]
+        [YAXSerializeAs("value")]
+        public ushort NEW_I_08 { get; set; }
+        [YAXAttributeFor("NEW_I_10")]
+        [YAXSerializeAs("value")]
+        public ushort NEW_I_10 { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("Type")]
         public ushort Type { get; set; } //ushort
@@ -320,6 +328,12 @@ namespace Xv2CoreLib.IDB
         [YAXAttributeFor("TPMedals")]
         [YAXSerializeAs("value")]
         public int I_28 { get; set; }
+        [YAXAttributeFor("NEW_I_32")]
+        [YAXSerializeAs("value")]
+        public int NEW_I_32 { get; set; }
+        [YAXAttributeFor("NEW_I_36")]
+        [YAXSerializeAs("value")]
+        public int NEW_I_36 { get; set; }
         [YAXAttributeFor("Model")]
         [YAXSerializeAs("value")]
         public int I_32 { get; set; } //int32
@@ -503,7 +517,8 @@ namespace Xv2CoreLib.IDB
     public class IBD_Effect
     {
         public const int OLD_ENTRY_SIZE = 224;
-        public const int NEW_ENTRY_SIZE = 232;
+        public const int ENTRY_SIZE_V1 = 232;
+        public const int ENTRY_SIZE_V2 = 236;
 
         [YAXAttributeFor("Type")]
         [YAXSerializeAs("value")]
@@ -514,6 +529,9 @@ namespace Xv2CoreLib.IDB
         [YAXAttributeFor("NumActTimes")]
         [YAXSerializeAs("value")]
         public int I_08 { get; set; } = -1;
+        [YAXAttributeFor("NEW_I_12")]
+        [YAXSerializeAs("value")]
+        public int NEW_I_12 { get; set; } = 0;
         [YAXAttributeFor("Timer")]
         [YAXSerializeAs("value")]
         [YAXFormat("0.0##########")]

--- a/Xv2CoreLib/IDB/IDB_File.cs
+++ b/Xv2CoreLib/IDB/IDB_File.cs
@@ -298,9 +298,9 @@ namespace Xv2CoreLib.IDB
         [YAXAttributeFor("Description")]
         [YAXSerializeAs("MSG_ID")]
         public ushort DescMsgID { get; set; }
-        [YAXAttributeFor("NEW_I_08")]
-        [YAXSerializeAs("value")]
-        public ushort NEW_I_08 { get; set; }
+        [YAXAttributeFor("HowMsgID")]
+        [YAXSerializeAs("MSG_ID")]
+        public ushort HowMsgID { get; set; } = ushort.MaxValue;
         [YAXAttributeFor("NEW_I_10")]
         [YAXSerializeAs("value")]
         public ushort NEW_I_10 { get; set; }

--- a/Xv2CoreLib/IDB/Parser.cs
+++ b/Xv2CoreLib/IDB/Parser.cs
@@ -12,7 +12,8 @@ namespace Xv2CoreLib.IDB
         IDB_File idbFile = new IDB_File();
 
         public static int ENTRY_SIZE_OLD = IDB_Entry.OLD_ENTRY_SIZE + (IBD_Effect.OLD_ENTRY_SIZE * 3);
-        public static int ENTRY_SIZE_NEW = IDB_Entry.NEW_ENTRY_SIZE + (IBD_Effect.NEW_ENTRY_SIZE * 3);
+        public static int ENTRY_SIZE_V1 = IDB_Entry.ENTRY_SIZE_V1 + (IBD_Effect.ENTRY_SIZE_V1 * 3);
+        public static int ENTRY_SIZE_V2 = IDB_Entry.ENTRY_SIZE_V2 + (IBD_Effect.ENTRY_SIZE_V2 * 3);
 
 
         public Parser(string location, bool _writeXml = false)
@@ -55,9 +56,13 @@ namespace Xv2CoreLib.IDB
             {
                 idbFile.Version = 0;
             }
-            else if ((rawBytes.Length - 16) == ENTRY_SIZE_NEW * count)
+            else if ((rawBytes.Length - 16) == ENTRY_SIZE_V1 * count)
             {
                 idbFile.Version = 1;
+            }
+            else if ((rawBytes.Length - 16) == ENTRY_SIZE_V2 * count)
+            {
+                idbFile.Version = 2;
             }
             else
             {
@@ -74,7 +79,8 @@ namespace Xv2CoreLib.IDB
                         ReadEntryOld(count, offset);
                         break;
                     case 1:
-                        ReadEntryNew(count, offset);
+                    case 2:
+                        ReadEntryNew(count, offset, idbFile.Version);
                         break;
                 }
             }
@@ -156,81 +162,173 @@ namespace Xv2CoreLib.IDB
 
 
 
-        private void ReadEntryNew(int count, int offset)
+        private void ReadEntryNew(int count, int offset, int version)
         {
             for (int i = 0; i < count; i++)
             {
-                idbFile.Entries.Add(new IDB_Entry()
+                // I wanted to do a similar version check like what is done with the CST files
+                // But I couldn't exactly figure out how I would do that in this case
+
+                if (version != 1 && version != 2)
+                    throw new InvalidDataException($"IDB: This IDB version is not supported (Version: {version}).");
+
+                if (version == 1)
                 {
-                    ID = BitConverter.ToUInt16(rawBytes, offset + 0),
-                    I_02 = BitConverter.ToUInt16(rawBytes, offset + 2),
-                    NameMsgID = BitConverter.ToUInt16(rawBytes, offset + 4),
-                    DescMsgID = BitConverter.ToUInt16(rawBytes, offset + 6),
-                    Type = BitConverter.ToUInt16(rawBytes, offset + 8),
-                    I_10 = BitConverter.ToUInt16(rawBytes, offset + 10),
-                    NEW_I_12 = BitConverter.ToUInt16(rawBytes, offset + 12),
-                    NEW_I_14 = BitConverter.ToUInt16(rawBytes, offset + 14),
+                    idbFile.Entries.Add(new IDB_Entry()
+                    {
+                        ID = BitConverter.ToUInt16(rawBytes, offset + 0),
+                        I_02 = BitConverter.ToUInt16(rawBytes, offset + 2),
+                        NameMsgID = BitConverter.ToUInt16(rawBytes, offset + 4),
+                        DescMsgID = BitConverter.ToUInt16(rawBytes, offset + 6),
+                        Type = BitConverter.ToUInt16(rawBytes, offset + 8),
+                        I_10 = BitConverter.ToUInt16(rawBytes, offset + 10),
+                        NEW_I_12 = BitConverter.ToUInt16(rawBytes, offset + 12),
+                        NEW_I_14 = BitConverter.ToUInt16(rawBytes, offset + 14),
 
-                    I_12 = BitConverter.ToUInt16(rawBytes, offset + 16),
-                    I_14 = BitConverter.ToUInt16(rawBytes, offset + 18),
-                    I_16 = BitConverter.ToInt32(rawBytes, offset + 20),
-                    I_20 = BitConverter.ToInt32(rawBytes, offset + 24),
-                    RaceLock = (IdbRaceLock)BitConverter.ToInt32(rawBytes, offset + 28),
-                    I_28 = BitConverter.ToInt32(rawBytes, offset + 32),
-                    I_32 = BitConverter.ToInt32(rawBytes, offset + 36),
-                    I_36 = BitConverter.ToUInt16(rawBytes, offset + 40),
-                    I_38 = (LB_Color)BitConverter.ToUInt16(rawBytes, offset + 42),
-                    I_40 = BitConverter.ToUInt16(rawBytes, offset + 44),
-                    I_42 = BitConverter.ToUInt16(rawBytes, offset + 46),
-                    I_44 = BitConverter.ToUInt16(rawBytes, offset + 48),
-                    I_46 = BitConverter.ToUInt16(rawBytes, offset + 50),
-                    Effects = ReadEffectNew(offset + 52)
-                });
+                        I_12 = BitConverter.ToUInt16(rawBytes, offset + 16),
+                        I_14 = BitConverter.ToUInt16(rawBytes, offset + 18),
+                        I_16 = BitConverter.ToInt32(rawBytes, offset + 20),
+                        I_20 = BitConverter.ToInt32(rawBytes, offset + 24),
+                        RaceLock = (IdbRaceLock)BitConverter.ToInt32(rawBytes, offset + 28),
+                        I_28 = BitConverter.ToInt32(rawBytes, offset + 32),
+                        I_32 = BitConverter.ToInt32(rawBytes, offset + 36),
+                        I_36 = BitConverter.ToUInt16(rawBytes, offset + 40),
+                        I_38 = (LB_Color)BitConverter.ToUInt16(rawBytes, offset + 42),
+                        I_40 = BitConverter.ToUInt16(rawBytes, offset + 44),
+                        I_42 = BitConverter.ToUInt16(rawBytes, offset + 46),
+                        I_44 = BitConverter.ToUInt16(rawBytes, offset + 48),
+                        I_46 = BitConverter.ToUInt16(rawBytes, offset + 50),
+                        Effects = ReadEffectNew(offset + 52, version)
+                    });
 
-                offset += ENTRY_SIZE_NEW;
+                    offset += ENTRY_SIZE_V1;
+                }
+
+                if (version >= 2)
+                {
+                    idbFile.Entries.Add(new IDB_Entry()
+                    {
+                        ID = BitConverter.ToUInt16(rawBytes, offset + 0),
+                        I_02 = BitConverter.ToUInt16(rawBytes, offset + 2),
+                        NameMsgID = BitConverter.ToUInt16(rawBytes, offset + 4),
+                        DescMsgID = BitConverter.ToUInt16(rawBytes, offset + 6),
+                        NEW_I_08 = BitConverter.ToUInt16(rawBytes, offset + 8),
+                        NEW_I_10 = BitConverter.ToUInt16(rawBytes, offset + 10),
+                        Type = BitConverter.ToUInt16(rawBytes, offset + 12),
+                        I_10 = BitConverter.ToUInt16(rawBytes, offset + 14),
+                        NEW_I_12 = BitConverter.ToUInt16(rawBytes, offset + 16),
+                        NEW_I_14 = BitConverter.ToUInt16(rawBytes, offset + 18),
+
+                        I_12 = BitConverter.ToUInt16(rawBytes, offset + 20),
+                        I_14 = BitConverter.ToUInt16(rawBytes, offset + 22),
+                        I_16 = BitConverter.ToInt32(rawBytes, offset + 24),
+                        I_20 = BitConverter.ToInt32(rawBytes, offset + 28),
+                        RaceLock = (IdbRaceLock)BitConverter.ToInt32(rawBytes, offset + 32),
+                        I_28 = BitConverter.ToInt32(rawBytes, offset + 36),
+                        NEW_I_32 = BitConverter.ToInt32(rawBytes, offset + 40),
+                        NEW_I_36 = BitConverter.ToInt32(rawBytes, offset + 44),
+                        I_32 = BitConverter.ToInt32(rawBytes, offset + 48),
+                        I_36 = BitConverter.ToUInt16(rawBytes, offset + 52),
+                        I_38 = (LB_Color)BitConverter.ToUInt16(rawBytes, offset + 54),
+                        I_40 = BitConverter.ToUInt16(rawBytes, offset + 56),
+                        I_42 = BitConverter.ToUInt16(rawBytes, offset + 58),
+                        I_44 = BitConverter.ToUInt16(rawBytes, offset + 60),
+                        I_46 = BitConverter.ToUInt16(rawBytes, offset + 62),
+                        Effects = ReadEffectNew(offset + 64, version)
+                    });
+
+                    offset += ENTRY_SIZE_V2;
+                }
             }
         }
 
 
-        private List<IBD_Effect> ReadEffectNew(int offset)
+        private List<IBD_Effect> ReadEffectNew(int offset, int version)
         {
             List<IBD_Effect> effects = new List<IBD_Effect>();
 
-            for (int i = 0; i < 3; i++)
+            if (version != 1 && version != 2)
+                throw new InvalidDataException($"IDB: This IDB version is not supported (Version: {version}).");
+
+            if (version == 1)
             {
-                effects.Add(new IBD_Effect()
+                for (int i = 0; i < 3; i++)
                 {
-                    I_00 = BitConverter.ToInt32(rawBytes, offset + 0),
-                    I_04 = BitConverter.ToInt32(rawBytes, offset + 4),
-                    I_08 = BitConverter.ToInt32(rawBytes, offset + 8),
-                    F_12 = BitConverter.ToSingle(rawBytes, offset + 12),
-                    F_16 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 16, 6),
-                    I_40 = BitConverter.ToInt32(rawBytes, offset + 40),
-                    I_44 = BitConverter.ToInt32(rawBytes, offset + 44),
-                    NEW_I_48 = BitConverter.ToInt32(rawBytes, offset + 48),
-                    NEW_I_52 = BitConverter.ToInt32(rawBytes, offset + 52),
+                    effects.Add(new IBD_Effect()
+                    {
+                        I_00 = BitConverter.ToInt32(rawBytes, offset + 0),
+                        I_04 = BitConverter.ToInt32(rawBytes, offset + 4),
+                        I_08 = BitConverter.ToInt32(rawBytes, offset + 8),
+                        F_12 = BitConverter.ToSingle(rawBytes, offset + 12),
+                        F_16 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 16, 6),
+                        I_40 = BitConverter.ToInt32(rawBytes, offset + 40),
+                        I_44 = BitConverter.ToInt32(rawBytes, offset + 44),
+                        NEW_I_48 = BitConverter.ToInt32(rawBytes, offset + 48),
+                        NEW_I_52 = BitConverter.ToInt32(rawBytes, offset + 52),
 
 
-                    F_48 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 56, 6),
-                    I_72 = BitConverter_Ex.ToInt32Array(rawBytes, offset + 80, 6),
-                    F_96 = BitConverter.ToSingle(rawBytes, offset + 104),
-                    F_100 = BitConverter.ToSingle(rawBytes, offset + 108),
-                    F_104 = BitConverter.ToSingle(rawBytes, offset + 112),
-                    F_108 = BitConverter.ToSingle(rawBytes, offset + 116),
-                    F_112 = BitConverter.ToSingle(rawBytes, offset + 120),
-                    F_116 = BitConverter.ToSingle(rawBytes, offset + 124),
-                    F_120 = BitConverter.ToSingle(rawBytes, offset + 128),
-                    F_124 = BitConverter.ToSingle(rawBytes, offset + 132),
-                    F_128 = BitConverter.ToSingle(rawBytes, offset + 136),
-                    F_132 = BitConverter.ToSingle(rawBytes, offset + 140),
-                    F_136 = BitConverter.ToSingle(rawBytes, offset + 144),
-                    F_140 = BitConverter.ToSingle(rawBytes, offset + 148),
-                    F_144 = BitConverter.ToSingle(rawBytes, offset + 152),
-                    F_148 = BitConverter.ToSingle(rawBytes, offset + 156),
-                    F_152 = BitConverter.ToSingle(rawBytes, offset + 160),
-                    F_156 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 164, 17)
-                });
-                offset += 232;
+                        F_48 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 56, 6),
+                        I_72 = BitConverter_Ex.ToInt32Array(rawBytes, offset + 80, 6),
+                        F_96 = BitConverter.ToSingle(rawBytes, offset + 104),
+                        F_100 = BitConverter.ToSingle(rawBytes, offset + 108),
+                        F_104 = BitConverter.ToSingle(rawBytes, offset + 112),
+                        F_108 = BitConverter.ToSingle(rawBytes, offset + 116),
+                        F_112 = BitConverter.ToSingle(rawBytes, offset + 120),
+                        F_116 = BitConverter.ToSingle(rawBytes, offset + 124),
+                        F_120 = BitConverter.ToSingle(rawBytes, offset + 128),
+                        F_124 = BitConverter.ToSingle(rawBytes, offset + 132),
+                        F_128 = BitConverter.ToSingle(rawBytes, offset + 136),
+                        F_132 = BitConverter.ToSingle(rawBytes, offset + 140),
+                        F_136 = BitConverter.ToSingle(rawBytes, offset + 144),
+                        F_140 = BitConverter.ToSingle(rawBytes, offset + 148),
+                        F_144 = BitConverter.ToSingle(rawBytes, offset + 152),
+                        F_148 = BitConverter.ToSingle(rawBytes, offset + 156),
+                        F_152 = BitConverter.ToSingle(rawBytes, offset + 160),
+                        F_156 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 164, 17)
+                    });
+                    offset += 232;
+                }
+            }
+
+            if (version == 2)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    effects.Add(new IBD_Effect()
+                    {
+                        I_00 = BitConverter.ToInt32(rawBytes, offset + 0),
+                        I_04 = BitConverter.ToInt32(rawBytes, offset + 4),
+                        I_08 = BitConverter.ToInt32(rawBytes, offset + 8),
+                        NEW_I_12 = BitConverter.ToInt32(rawBytes, offset + 12),
+                        F_12 = BitConverter.ToSingle(rawBytes, offset + 16),
+                        F_16 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 20, 6),
+                        I_40 = BitConverter.ToInt32(rawBytes, offset + 44),
+                        I_44 = BitConverter.ToInt32(rawBytes, offset + 48),
+                        NEW_I_48 = BitConverter.ToInt32(rawBytes, offset + 52),
+                        NEW_I_52 = BitConverter.ToInt32(rawBytes, offset + 56),
+
+
+                        F_48 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 60, 6),
+                        I_72 = BitConverter_Ex.ToInt32Array(rawBytes, offset + 84, 6),
+                        F_96 = BitConverter.ToSingle(rawBytes, offset + 108),
+                        F_100 = BitConverter.ToSingle(rawBytes, offset + 112),
+                        F_104 = BitConverter.ToSingle(rawBytes, offset + 116),
+                        F_108 = BitConverter.ToSingle(rawBytes, offset + 120),
+                        F_112 = BitConverter.ToSingle(rawBytes, offset + 124),
+                        F_116 = BitConverter.ToSingle(rawBytes, offset + 128),
+                        F_120 = BitConverter.ToSingle(rawBytes, offset + 132),
+                        F_124 = BitConverter.ToSingle(rawBytes, offset + 136),
+                        F_128 = BitConverter.ToSingle(rawBytes, offset + 140),
+                        F_132 = BitConverter.ToSingle(rawBytes, offset + 144),
+                        F_136 = BitConverter.ToSingle(rawBytes, offset + 148),
+                        F_140 = BitConverter.ToSingle(rawBytes, offset + 152),
+                        F_144 = BitConverter.ToSingle(rawBytes, offset + 156),
+                        F_148 = BitConverter.ToSingle(rawBytes, offset + 160),
+                        F_152 = BitConverter.ToSingle(rawBytes, offset + 164),
+                        F_156 = BitConverter_Ex.ToFloat32Array(rawBytes, offset + 168, 17)
+                    });
+                    offset += 236;
+                }
             }
 
             return effects;

--- a/Xv2CoreLib/IDB/Parser.cs
+++ b/Xv2CoreLib/IDB/Parser.cs
@@ -212,7 +212,7 @@ namespace Xv2CoreLib.IDB
                         I_02 = BitConverter.ToUInt16(rawBytes, offset + 2),
                         NameMsgID = BitConverter.ToUInt16(rawBytes, offset + 4),
                         DescMsgID = BitConverter.ToUInt16(rawBytes, offset + 6),
-                        NEW_I_08 = BitConverter.ToUInt16(rawBytes, offset + 8),
+                        HowMsgID = BitConverter.ToUInt16(rawBytes, offset + 8),
                         NEW_I_10 = BitConverter.ToUInt16(rawBytes, offset + 10),
                         Type = BitConverter.ToUInt16(rawBytes, offset + 12),
                         I_10 = BitConverter.ToUInt16(rawBytes, offset + 14),


### PR DESCRIPTION
Updated parsing for IDB files that were changed in version 1.22

Added a version check so old IDB files (from version 1.18) are still compatible, the code could definitely be better for the version checks and I might touch it up when I have more time. 

Thanks to @Atsuraelu for helping me figure the new format!