### PR TITLE
Add installer oct pso ocp support

### DIFF
--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -148,6 +148,7 @@ namespace LB_Mod_Installer.Installer
                 else
                 {
                     MessageBox.Show("No changes were made to the installation. The installer will now close.", "Install Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                    Parent.ShutdownApp();
                 }
                 Parent.ShutdownApp();
             }

--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -148,7 +148,6 @@ namespace LB_Mod_Installer.Installer
                 else
                 {
                     MessageBox.Show("No changes were made to the installation. The installer will now close.", "Install Error", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-                    Parent.ShutdownApp();
                 }
                 Parent.ShutdownApp();
             }

--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -1980,7 +1980,7 @@ namespace LB_Mod_Installer.Installer
 #endif
             {
                 OCP_File xmlFile = (isXml) ? zipManager.DeserializeXmlFromArchive_Ext<OCP_File>(GeneralInfo.GetPathInZipDataDir(xmlPath)) : OCP_File.Load(zipManager.GetFileFromArchive(GeneralInfo.GetPathInZipDataDir(xmlPath)));
-                OCP_File binaryFile = (OCP_File)GetParsedFile<OCO_File>(installPath);
+                OCP_File binaryFile = (OCP_File)GetParsedFile<OCP_File>(installPath);
 
                 //Install entries
                 InstallSubEntries<OCP_SubEntry, OCP_TableEntry>(xmlFile.TableEntries, binaryFile.TableEntries, installPath, Sections.OCP_Entry, useSkipBindings);

--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -55,6 +55,7 @@ using Xv2CoreLib.QED;
 using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
 using Xv2CoreLib.EEPK;
+using Xv2CoreLib.OCT;
 //using LB_Mod_Installer.Installer.Transformation;
 
 namespace LB_Mod_Installer.Installer
@@ -375,6 +376,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".oco":
                     Install_OCO(xmlPath, installPath, isXml, useSkipBindings);
+                    break;
+                case ".oct":
+                    Install_OCT(xmlPath, installPath, isXml, useSkipBindings);
                     break;
                 case ".dml":
                     Install_DML(xmlPath, installPath, isXml, useSkipBindings);
@@ -1939,6 +1943,27 @@ namespace LB_Mod_Installer.Installer
 #endif
         }
 
+        private void Install_OCT(string xmlPath, string installPath, bool isXml, bool useSkipBindings)
+        {
+#if !DEBUG
+            try
+#endif
+            {
+                OCT_File xmlFile = (isXml) ? zipManager.DeserializeXmlFromArchive_Ext<OCT_File>(GeneralInfo.GetPathInZipDataDir(xmlPath)) : OCT_File.Load(zipManager.GetFileFromArchive(GeneralInfo.GetPathInZipDataDir(xmlPath)));
+                OCT_File binaryFile = (OCT_File)GetParsedFile<OCT_File>(installPath);
+
+                //Install entries
+                InstallSubEntries<OCT_SubEntry, OCT_TableEntry>(xmlFile.OctTableEntries, binaryFile.OctTableEntries, installPath, Sections.OCT_Entry, useSkipBindings);
+            }
+#if !DEBUG
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at OCT install phase ({0}).", xmlPath);
+                throw new Exception(error, ex);
+            }
+#endif
+        }
+
         private void Install_DML(string xmlPath, string installPath, bool isXml, bool useSkipBindings)
         {
 #if !DEBUG
@@ -2467,6 +2492,8 @@ namespace LB_Mod_Installer.Installer
                     return OCS_File.Load(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
                 case ".oco":
                     return OCO_File.Load(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
+                case ".oct":
+                    return OCT_File.Load(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
                 case ".qml":
                     return QML_File.Load(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
                 case ".qbt":
@@ -2579,6 +2606,8 @@ namespace LB_Mod_Installer.Installer
                     return ((OCS_File)data).SaveToBytes();
                 case ".oco":
                     return ((OCO_File)data).SaveToBytes();
+                case ".oct":
+                    return ((OCT_File)data).SaveToBytes();
                 case ".qml":
                     return ((QML_File)data).SaveToBytes();
                 case ".qbt":

--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -52,6 +52,7 @@ using Xv2CoreLib.ODF;
 using Xv2CoreLib.BCM;
 using Xv2CoreLib.OCT;
 using Xv2CoreLib.PSO;
+using Xv2CoreLib.OCP;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -305,6 +306,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".oct":
                     Uninstall_OCT(path, file);
+                    break;
+                case ".ocp":
+                    Uninstall_OCP(path, file);
                     break;
                 case ".dml":
                     Uninstall_DML(path, file);
@@ -1414,6 +1418,22 @@ namespace LB_Mod_Installer.Installer
             catch (Exception ex)
             {
                 string error = string.Format("Failed at OCT uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
+
+        private void Uninstall_OCP(string path, _File file)
+        {
+            try
+            {
+                OCP_File binaryFile = (OCP_File)GetParsedFile<OCP_File>(path, false);
+                OCP_File cpkBinFile = (OCP_File)GetParsedFile<OCP_File>(path, true);
+
+                UninstallSubEntries<OCP_SubEntry, OCP_TableEntry>(binaryFile.TableEntries, (cpkBinFile != null) ? cpkBinFile.TableEntries : null, file, true);
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at OCP uninstall phase ({0}).", path);
                 throw new Exception(error, ex);
             }
         }

--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -51,6 +51,7 @@ using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
 using Xv2CoreLib.BCM;
 using Xv2CoreLib.OCT;
+using Xv2CoreLib.PSO;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -325,6 +326,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".odf":
                     Uninstall_ODF(path, file);
+                    break;
+                case ".pso":
+                    Uninstall_PSO(path, file);
                     break;
                 case ".bcm":
                     Uninstall_BCM(path, file);
@@ -1572,7 +1576,29 @@ namespace LB_Mod_Installer.Installer
                 throw new Exception(error, ex);
             }
         }
-        
+
+        private void Uninstall_PSO(string path, _File file)
+        {
+            try
+            {
+                PSO_File binaryFile = (PSO_File)GetParsedFile<PSO_File>(path, false);
+                PSO_File cpkBinFile = (PSO_File)GetParsedFile<PSO_File>(path, true, true);
+
+                Section section = file.GetSection(Sections.PSO_Entry);
+
+                if (section != null)
+                {
+                    UninstallEntries(binaryFile.PsoEntries[0].PsoSubEntries, (cpkBinFile != null) ? cpkBinFile.PsoEntries[0].PsoSubEntries : null, section.IDs);
+                }
+
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at PSO uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
+
         private void Uninstall_BCM(string path, _File file)
         {
             try

--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -50,6 +50,7 @@ using Xv2CoreLib.QBT;
 using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
 using Xv2CoreLib.BCM;
+using Xv2CoreLib.OCT;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -300,6 +301,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".oco":
                     Uninstall_OCO(path, file);
+                    break;
+                case ".oct":
+                    Uninstall_OCT(path, file);
                     break;
                 case ".dml":
                     Uninstall_DML(path, file);
@@ -1390,6 +1394,22 @@ namespace LB_Mod_Installer.Installer
             catch (Exception ex)
             {
                 string error = string.Format("Failed at OCO uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
+
+        private void Uninstall_OCT(string path, _File file)
+        {
+            try
+            {
+                OCT_File binaryFile = (OCT_File)GetParsedFile<OCT_File>(path, false);
+                OCT_File cpkBinFile = (OCT_File)GetParsedFile<OCT_File>(path, true);
+
+                UninstallSubEntries<OCT_SubEntry, OCT_TableEntry>(binaryFile.OctTableEntries, (cpkBinFile != null) ? cpkBinFile.OctTableEntries : null, file, true);
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at OCT uninstall phase ({0}).", path);
                 throw new Exception(error, ex);
             }
         }

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -60,6 +60,7 @@
         public const string DML_Entry = "DML_Entry";
         public const string TNN_Tutorial = "TNN_Tutorial";
         public const string ODF_Entry = "ODF_Entry";
+        public const string PSO_Entry = "PSO_Entry";
         public const string BCM_Entry = "BCM_Entry";
 
         public const string TTB_Entry = "TTB_Entry";

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -69,6 +69,7 @@
         public const string CML_Entry = "CML_Entry";
         public const string OCS_Skill = "OCS_Skill";
         public const string OCO_Entry = "OCO_Entry";
+        public const string OCT_Entry = "OCT_Entry";
         public const string QML_Entry = "QML_Entry";
         public const string CST_Entry = "CST_Entry";
         public const string CharaSlotEntry = "CharaSlotEntry";

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -71,6 +71,7 @@
         public const string OCS_Skill = "OCS_Skill";
         public const string OCO_Entry = "OCO_Entry";
         public const string OCT_Entry = "OCT_Entry";
+        public const string OCP_Entry = "OCP_Entry";
         public const string QML_Entry = "QML_Entry";
         public const string CST_Entry = "CST_Entry";
         public const string CharaSlotEntry = "CharaSlotEntry";

--- a/Xv2CoreLib/BAC/BAC_File.cs
+++ b/Xv2CoreLib/BAC/BAC_File.cs
@@ -4283,6 +4283,7 @@ namespace Xv2CoreLib.BAC
         public enum HomingFlagsEnum : ushort
         {
             EnableAutoTracking = 0x1,
+            Left = 0x1,
             UseFloatSpeedModifier = 0x2,
             Unk3 = 0x4,
             UseBones = 0x8,
@@ -5244,9 +5245,9 @@ namespace Xv2CoreLib.BAC
         [YAXAttributeFor("I_10")]
         [YAXSerializeAs("value")]
         public ushort I_10 { get; set; }
-        [YAXAttributeFor("F_12")]
+        [YAXAttributeFor("I_12")]
         [YAXSerializeAs("value")]
-        public float F_12 { get; set; }
+        public int I_12 { get; set; }
         [YAXAttributeFor("F_16")]
         [YAXSerializeAs("value")]
         public float F_16 { get; set; }
@@ -5278,7 +5279,7 @@ namespace Xv2CoreLib.BAC
 
                     I_08 = BitConverter.ToUInt16(rawBytes, offset + 8),
                     I_10 = BitConverter.ToUInt16(rawBytes, offset + 10),
-                    F_12 = BitConverter.ToSingle(rawBytes, offset + 12),
+                    I_12 = BitConverter.ToInt32(rawBytes, offset + 12),
                     F_16 = BitConverter.ToSingle(rawBytes, offset + 16),
                     F_20 = BitConverter.ToSingle(rawBytes, offset + 20),
                     I_24 = BitConverter.ToInt32(rawBytes, offset + 24),
@@ -5306,7 +5307,7 @@ namespace Xv2CoreLib.BAC
                 bytes.AddRange(BitConverter.GetBytes(type.Flags));
                 bytes.AddRange(BitConverter.GetBytes(type.I_08));
                 bytes.AddRange(BitConverter.GetBytes(type.I_10));
-                bytes.AddRange(BitConverter.GetBytes(type.F_12));
+                bytes.AddRange(BitConverter.GetBytes(type.I_12));
                 bytes.AddRange(BitConverter.GetBytes(type.F_16));
                 bytes.AddRange(BitConverter.GetBytes(type.F_20));
                 bytes.AddRange(BitConverter.GetBytes(type.I_24));

--- a/Xv2CoreLib/CST/CST_File.cs
+++ b/Xv2CoreLib/CST/CST_File.cs
@@ -471,10 +471,11 @@ namespace Xv2CoreLib.CST
         public int I_44 { get; set; }
         [YAXAttributeFor("flag_cgk2")]
         [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public ushort flag_cgk2 { get; set; } // 0x30 - Added in game v 1.22. Adds the "Ultra Supervillain" to the name in CSS
         [YAXAttributeFor("I_50")]
         [YAXSerializeAs("value")]
-        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 0)]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public ushort I_50 { get; set; }
 
         public CST_CharaCostumeSlot() { }
@@ -490,6 +491,7 @@ namespace Xv2CoreLib.CST
             CssVoice2 = slot.CssVoice2 < 0 ? ushort.MaxValue : (ushort)slot.CssVoice2;
             DlcFlag1 = slot.DLC_Flag1;
             DlcFlag2 = slot.DLC_Flag2;
+            flag_cgk2 = (ushort)(slot.flag_cgk2 == true ? 1 : 0);
         }
 
         public static CST_CharaCostumeSlot Read(byte[] bytes, int offset, int version)
@@ -573,7 +575,8 @@ namespace Xv2CoreLib.CST
                 CssVoice1 = CssVoice1,
                 CssVoice2 = CssVoice2,
                 DLC_Flag1 = DlcFlag1,
-                Costume = Costume
+                Costume = Costume,
+                flag_cgk2 = (flag_cgk2 == 0) ? false : true
             };
         }
     };

--- a/Xv2CoreLib/Eternity/CharaSlotsFile.cs
+++ b/Xv2CoreLib/Eternity/CharaSlotsFile.cs
@@ -71,7 +71,7 @@ namespace Xv2CoreLib.Eternity
                     CharaCostumeSlot costumeSlot = new CharaCostumeSlot();
                     
                     string[] parameters = costume.Split(',');
-                    if (parameters.Length != 9) throw new InvalidDataException($"Invalid number of CharaSlot parameters. Expected 9, found {parameters.Length}.");
+                    if (parameters.Length != 10) throw new InvalidDataException($"Invalid number of CharaSlot parameters. Expected 10, found {parameters.Length}.");
 
                     costumeSlot.CharaCode = parameters[0];
                     costumeSlot.Costume = int.Parse(parameters[1]);
@@ -82,6 +82,7 @@ namespace Xv2CoreLib.Eternity
                     costumeSlot.CssVoice2 = int.Parse(parameters[6]);
                     costumeSlot.DLC_Flag1 = (CstDlcVer)uint.Parse(parameters[7]);
                     costumeSlot.DLC_Flag2 = (CstDlcVer2)uint.Parse(parameters[8]);
+                    costumeSlot.flag_cgk2 = (parameters[9] == "1") ? true : false;
 
                     charaSlot.CostumeSlots.Add(costumeSlot);
                 }
@@ -112,7 +113,8 @@ namespace Xv2CoreLib.Eternity
                     strBuilder.Append(costume.CssVoice1).Append(",");
                     strBuilder.Append(costume.CssVoice2).Append(",");
                     strBuilder.Append((uint)costume.DLC_Flag1).Append(",");
-                    strBuilder.Append((uint)costume.DLC_Flag2);
+                    strBuilder.Append((uint)costume.DLC_Flag2).Append(",");
+                    strBuilder.Append((costume.flag_cgk2) ? 1 : 0);
 
                     strBuilder.Append("]");
                 }
@@ -226,7 +228,10 @@ namespace Xv2CoreLib.Eternity
         [YAXAttributeForClass]
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = (CstDlcVer2)0)]
         public CstDlcVer2 DLC_Flag2 { get; set; }
-    
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = false)]
+        public bool flag_cgk2 { get; set; }
+
         public CharaCostumeSlot() { }
 
         public CharaCostumeSlot(CST_CharaCostumeSlot slot)
@@ -240,6 +245,7 @@ namespace Xv2CoreLib.Eternity
             CssVoice2 = slot.CssVoice2 == ushort.MaxValue ? -1 : slot.CssVoice2;
             DLC_Flag1 = slot.DlcFlag1;
             DLC_Flag2 = slot.DlcFlag2;
+            flag_cgk2 = slot.flag_cgk2 > 0;
         }
     }
 }

--- a/Xv2CoreLib/IDB/IDB_File.cs
+++ b/Xv2CoreLib/IDB/IDB_File.cs
@@ -300,9 +300,11 @@ namespace Xv2CoreLib.IDB
         public ushort DescMsgID { get; set; }
         [YAXAttributeFor("HowMsgID")]
         [YAXSerializeAs("MSG_ID")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public ushort HowMsgID { get; set; } = ushort.MaxValue;
         [YAXAttributeFor("NEW_I_10")]
         [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public ushort NEW_I_10 { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("Type")]
@@ -330,9 +332,11 @@ namespace Xv2CoreLib.IDB
         public int I_28 { get; set; }
         [YAXAttributeFor("STPMedals")]
         [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int NEW_I_32 { get; set; }
         [YAXAttributeFor("NEW_I_36")]
         [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int NEW_I_36 { get; set; }
         [YAXAttributeFor("Model")]
         [YAXSerializeAs("value")]
@@ -531,6 +535,7 @@ namespace Xv2CoreLib.IDB
         public int I_08 { get; set; } = -1;
         [YAXAttributeFor("NEW_I_12")]
         [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int NEW_I_12 { get; set; } = 0;
         [YAXAttributeFor("Timer")]
         [YAXSerializeAs("value")]

--- a/Xv2CoreLib/OCP/Deserializer.cs
+++ b/Xv2CoreLib/OCP/Deserializer.cs
@@ -11,21 +11,27 @@ namespace Xv2CoreLib.OCP
     public class Deserializer
     {
         string saveLocation;
-        OCP_File octFile;
-        List<byte> bytes = new List<byte>() { 35, 79, 67, 80, 254, 255, 16, 0 };
+        OCP_File ocpFile;
+        public List<byte> bytes = new List<byte>() { 35, 79, 67, 80, 254, 255, 16, 0 };
 
         public Deserializer(string location)
         {
             saveLocation = String.Format("{0}/{1}", Path.GetDirectoryName(location), Path.GetFileNameWithoutExtension(location));
             YAXSerializer serializer = new YAXSerializer(typeof(OCP_File), YAXSerializationOptions.DontSerializeNullObjects);
-            octFile = (OCP_File)serializer.DeserializeFromFile(location);
+            ocpFile = (OCP_File)serializer.DeserializeFromFile(location);
             Write();
             File.WriteAllBytes(saveLocation, bytes.ToArray());
         }
 
+        public Deserializer(OCP_File ocpFile)
+        {
+            this.ocpFile = ocpFile;
+            Write();
+        }
+
         private void Write()
         {
-            int count = (octFile.TableEntries != null) ? octFile.TableEntries.Count() : 0;
+            int count = (ocpFile.TableEntries != null) ? ocpFile.TableEntries.Count() : 0;
             bytes.AddRange(BitConverter.GetBytes(count));
             bytes.AddRange(new byte[4]);
 
@@ -35,26 +41,26 @@ namespace Xv2CoreLib.OCP
 
             for(int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.TableEntries[i].SubEntries != null) ? octFile.TableEntries[i].SubEntries.Count() : 0;
+                int subDataCount = (ocpFile.TableEntries[i].SubEntries != null) ? ocpFile.TableEntries[i].SubEntries.Count() : 0;
                 bytes.AddRange(BitConverter.GetBytes(subDataCount));
                 bytes.AddRange(BitConverter.GetBytes(dataOffset));
                 bytes.AddRange(BitConverter.GetBytes(currentIndex));
-                bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].Index));
+                bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].PartnerID));
                 currentIndex += subDataCount;
             }
 
             //Table Entries
             for (int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.TableEntries[i].SubEntries != null) ? octFile.TableEntries[i].SubEntries.Count() : 0;
+                int subDataCount = (ocpFile.TableEntries[i].SubEntries != null) ? ocpFile.TableEntries[i].SubEntries.Count() : 0;
 
                 for(int a = 0; a < subDataCount; a++)
                 {
-                    bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].Index));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].SubEntries[a].Index));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].SubEntries[a].I_08));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].SubEntries[a].I_12));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.TableEntries[i].SubEntries[a].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].PartnerID));
+                    bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].SubEntries[a].I_04));
+                    bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].SubEntries[a].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].SubEntries[a].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(ocpFile.TableEntries[i].SubEntries[a].I_16));
                 }
 
             }

--- a/Xv2CoreLib/OCP/OCP_File.cs
+++ b/Xv2CoreLib/OCP/OCP_File.cs
@@ -8,18 +8,36 @@ using YAXLib;
 namespace Xv2CoreLib.OCP
 {
     [YAXSerializeAs("OCP")]
-    class OCP_File
+    public class OCP_File
     {
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Partner")]
         public List<OCP_TableEntry> TableEntries { get; set; }
+
+        #region LoadSave
+        public static OCP_File Load(byte[] bytes)
+        {
+            return new Parser(bytes).ocpFile;
+        }
+
+        public byte[] SaveToBytes()
+        {
+            return new Deserializer(this).bytes.ToArray();
+        }
+        #endregion
     }
 
     [YAXSerializeAs("Partner")]
-    public class OCP_TableEntry
+    public class OCP_TableEntry : IInstallable_2<OCP_SubEntry>, IInstallable
     {
+        #region Installer
+        [YAXDontSerialize]
+        public int SortID { get { return PartnerID; } set { PartnerID = value; } }
+        [YAXDontSerialize]
+        public string Index { get { return PartnerID.ToString(); } set { PartnerID = Utils.TryParseInt(value); } }
+        #endregion
         [YAXAttributeForClass]
         [YAXSerializeAs("Partner_ID")]
-        public uint Index { get; set; }
+        public int PartnerID { get; set; }
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "StatType")]
         public List<OCP_SubEntry> SubEntries { get; set; }
         
@@ -27,12 +45,19 @@ namespace Xv2CoreLib.OCP
     }
 
     [YAXSerializeAs("StatType")]
-    public class OCP_SubEntry
+    public class OCP_SubEntry : IInstallable
     {
+
+        #region Installer
+        [YAXDontSerialize]
+        public int SortID { get { return I_04; } set { I_04 = value; } }
+        [YAXDontSerialize]
+        public string Index { get { return I_04.ToString(); } set { I_04 = Utils.TryParseInt(value); } }
+        #endregion
 
         [YAXAttributeForClass]
         [YAXSerializeAs("Order")]
-        public uint Index { get; set; } //0x4
+        public int I_04 { get; set; } //0x4
         [YAXAttributeFor("TP_Cost_Toggle")]
         [YAXSerializeAs("value")]
         public int I_08 { get; set; } // uint32

--- a/Xv2CoreLib/OCP/Parser.cs
+++ b/Xv2CoreLib/OCP/Parser.cs
@@ -12,7 +12,7 @@ namespace Xv2CoreLib.OCP
     {
         string saveLocation;
         byte[] rawBytes;
-        private OCP_File octFile = new OCP_File();
+        public OCP_File ocpFile = new OCP_File();
 
         public Parser(string path, bool _writeXml)
         {
@@ -24,8 +24,15 @@ namespace Xv2CoreLib.OCP
             if (_writeXml)
             {
                 YAXSerializer serializer = new YAXSerializer(typeof(OCP_File));
-                serializer.SerializeToFile(octFile, saveLocation + ".xml");
+                serializer.SerializeToFile(ocpFile, saveLocation + ".xml");
             }
+        }
+
+        public Parser(byte[] bytes)
+        {
+            rawBytes = bytes;
+
+            Parse();
         }
 
         private void Parse()
@@ -35,24 +42,24 @@ namespace Xv2CoreLib.OCP
 
             if (count > 0)
             {
-                octFile.TableEntries = new List<OCP_TableEntry>();
+                ocpFile.TableEntries = new List<OCP_TableEntry>();
 
                 for(int i = 0; i < count; i++)
                 {
                     int subEntryCount = BitConverter.ToInt32(rawBytes, offset);
                     int subDataOffset = BitConverter.ToInt32(rawBytes, offset + 4) + (20 * BitConverter.ToInt32(rawBytes, offset + 8)) + 16;
-                    octFile.TableEntries.Add(new OCP_TableEntry() { Index = BitConverter.ToUInt32(rawBytes, offset + 12) });
+                    ocpFile.TableEntries.Add(new OCP_TableEntry() { PartnerID = BitConverter.ToInt32(rawBytes, offset + 12) });
                     
                     if(subEntryCount > 0)
                     {
-                        octFile.TableEntries[i].SubEntries = new List<OCP_SubEntry>();
+                        ocpFile.TableEntries[i].SubEntries = new List<OCP_SubEntry>();
                     }
 
                     for (int a = 0; a < subEntryCount; a++)
                     {
-                        octFile.TableEntries[i].SubEntries.Add(new OCP_SubEntry()
+                        ocpFile.TableEntries[i].SubEntries.Add(new OCP_SubEntry()
                         {
-                            Index = BitConverter.ToUInt32(rawBytes, subDataOffset + 4),
+                            I_04 = BitConverter.ToInt32(rawBytes, subDataOffset + 4),
                             I_08 = BitConverter.ToInt32(rawBytes, subDataOffset + 8),
                             I_12 = BitConverter.ToUInt32(rawBytes, subDataOffset + 12),
                             I_16 = BitConverter.ToUInt32(rawBytes, subDataOffset + 16)

--- a/Xv2CoreLib/OCS/OCS_File.cs
+++ b/Xv2CoreLib/OCS/OCS_File.cs
@@ -231,6 +231,7 @@ namespace Xv2CoreLib.OCS
         public int TP_Cost { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("STP_Cost")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int STP_Cost { get; set; } // Added in 1.22
         [YAXAttributeForClass]
         [YAXSerializeAs("ID2")]
@@ -240,6 +241,7 @@ namespace Xv2CoreLib.OCS
         public int DLC_Flag { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("NEW_I_32")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int NEW_I_32 { get; set; } // Added in 1.22
     }
 }

--- a/Xv2CoreLib/OCT/Deserializer.cs
+++ b/Xv2CoreLib/OCT/Deserializer.cs
@@ -12,7 +12,7 @@ namespace Xv2CoreLib.OCT
     {
         string saveLocation;
         OCT_File octFile;
-        List<byte> bytes = new List<byte>() { 35, 79, 67, 84, 254, 255};
+        public List<byte> bytes = new List<byte>() { 35, 79, 67, 84, 254, 255};
 
         public Deserializer(string location)
         {
@@ -21,6 +21,12 @@ namespace Xv2CoreLib.OCT
             octFile = (OCT_File)serializer.DeserializeFromFile(location);
             Write();
             File.WriteAllBytes(saveLocation, bytes.ToArray());
+        }
+
+        public Deserializer(OCT_File octFile)
+        {
+            this.octFile = octFile;
+            Write();
         }
 
         private void Write()
@@ -37,33 +43,33 @@ namespace Xv2CoreLib.OCT
 
             for(int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.OctTableEntries[i].OctSubEntries != null) ? octFile.OctTableEntries[i].OctSubEntries.Count() : 0;
+                int subDataCount = (octFile.OctTableEntries[i].SubEntries != null) ? octFile.OctTableEntries[i].SubEntries.Count() : 0;
                 bytes.AddRange(BitConverter.GetBytes(subDataCount));
                 bytes.AddRange(BitConverter.GetBytes(dataOffset));
                 bytes.AddRange(BitConverter.GetBytes(currentIndex));
-                bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].Index));
+                bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].PartnerID));
                 currentIndex += subDataCount;
             }
 
             //Table Entries
             for (int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.OctTableEntries[i].OctSubEntries != null) ? octFile.OctTableEntries[i].OctSubEntries.Count() : 0;
+                int subDataCount = (octFile.OctTableEntries[i].SubEntries != null) ? octFile.OctTableEntries[i].SubEntries.Count() : 0;
 
                 for(int a = 0; a < subDataCount; a++)
                 {
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].Index));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].Index));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].I_08));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].PartnerID));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].I_04));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].I_12));
 
                     if (octFile.Version >= 24)
                     {
-                        bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].STP_Cost));
+                        bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].STP_Cost));
                     }
 
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].I_16));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].OctSubEntries[a].I_20));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(octFile.OctTableEntries[i].SubEntries[a].I_20));
                 }
 
             }

--- a/Xv2CoreLib/OCT/OCT_File.cs
+++ b/Xv2CoreLib/OCT/OCT_File.cs
@@ -4,34 +4,60 @@ using YAXLib;
 namespace Xv2CoreLib.OCT
 {
     [YAXSerializeAs("OCT")]
-    class OCT_File
+    public class OCT_File
     {
         [YAXAttributeForClass]
         public ushort Version { get; set; } // 0x6: 0x14 = pre 1.22, 0x18 = 1.22 or later
 
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Partner")]
         public List<OCT_TableEntry> OctTableEntries { get; set; }
+
+        #region LoadSave
+        public static OCT_File Load(byte[] bytes)
+        {
+            return new Parser(bytes).octFile;
+        }
+
+        public byte[] SaveToBytes()
+        {
+            return new Deserializer(this).bytes.ToArray();
+        }
+        #endregion
     }
 
     [YAXSerializeAs("Partner")]
-    public class OCT_TableEntry
+    public class OCT_TableEntry : IInstallable_2<OCT_SubEntry>, IInstallable
     {
+        #region Installer
+        [YAXDontSerialize]
+        public int SortID { get { return PartnerID; } set { PartnerID = value; } }
+        [YAXDontSerialize]
+        public string Index { get { return PartnerID.ToString(); } set { PartnerID = Utils.TryParseInt(value); } }
+        #endregion
+
         [YAXAttributeForClass]
         [YAXSerializeAs("Partner_ID")]
-        public uint Index { get; set; }
+        public int PartnerID { get; set; }
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "SuperSoul")]
-        public List<OCT_SubEntry> OctSubEntries { get; set; }
+        public List<OCT_SubEntry> SubEntries { get; set; }
         
 
     }
 
     [YAXSerializeAs("PartnerSuperSoul")]
-    public class OCT_SubEntry
+    public class OCT_SubEntry : IInstallable
     {
+
+        #region Installer
+        [YAXDontSerialize]
+        public int SortID { get { return I_04; } set { I_04 = value; } }
+        [YAXDontSerialize]
+        public string Index { get { return I_04.ToString(); } set { I_04 = Utils.TryParseInt(value); } }
+        #endregion
 
         [YAXAttributeForClass]
         [YAXSerializeAs("Order")]
-        public int Index { get; set; } //0x4
+        public int I_04 { get; set; } //0x4
         [YAXAttributeForClass]
         [YAXSerializeAs("Super_Soul")]
         public int I_16 { get; set; }

--- a/Xv2CoreLib/OCT/OCT_File.cs
+++ b/Xv2CoreLib/OCT/OCT_File.cs
@@ -43,6 +43,7 @@ namespace Xv2CoreLib.OCT
         public int I_12 { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("STP_Cost")] // New in 1.22
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
         public int STP_Cost { get; set; }
         [YAXAttributeForClass]
         [YAXSerializeAs("DLC_Flag")]

--- a/Xv2CoreLib/OCT/Parser.cs
+++ b/Xv2CoreLib/OCT/Parser.cs
@@ -10,7 +10,7 @@ namespace Xv2CoreLib.OCT
     {
         string saveLocation;
         byte[] rawBytes;
-        private OCT_File octFile = new OCT_File();
+        public OCT_File octFile = new OCT_File();
 
         public Parser(string path, bool _writeXml)
         {
@@ -24,6 +24,13 @@ namespace Xv2CoreLib.OCT
                 YAXSerializer serializer = new YAXSerializer(typeof(OCT_File));
                 serializer.SerializeToFile(octFile, saveLocation + ".xml");
             }
+        }
+
+        public Parser(byte[] bytes)
+        {
+            rawBytes = bytes;
+
+            Parse();
         }
 
         private void Parse()
@@ -46,11 +53,11 @@ namespace Xv2CoreLib.OCT
                     else
                         subDataOffset = BitConverter.ToInt32(rawBytes, offset + 4) + (24 * BitConverter.ToInt32(rawBytes, offset + 8)) + 16;
 
-                    octFile.OctTableEntries.Add(new OCT_TableEntry() { Index = BitConverter.ToUInt32(rawBytes, offset + 12) });
+                    octFile.OctTableEntries.Add(new OCT_TableEntry() { PartnerID = BitConverter.ToInt32(rawBytes, offset + 12) });
 
                     if (subEntryCount > 0)
                     {
-                        octFile.OctTableEntries[i].OctSubEntries = new List<OCT_SubEntry>();
+                        octFile.OctTableEntries[i].SubEntries = new List<OCT_SubEntry>();
                     }
 
                     for (int a = 0; a < subEntryCount; a++)
@@ -58,9 +65,9 @@ namespace Xv2CoreLib.OCT
                         switch (octFile.Version)
                         {
                             case 20:
-                                octFile.OctTableEntries[i].OctSubEntries.Add(new OCT_SubEntry()
+                                octFile.OctTableEntries[i].SubEntries.Add(new OCT_SubEntry()
                                 {
-                                    Index = BitConverter.ToInt32(rawBytes, subDataOffset + 4),
+                                    I_04 = BitConverter.ToInt32(rawBytes, subDataOffset + 4),
                                     I_08 = BitConverter.ToInt32(rawBytes, subDataOffset + 8),
                                     I_12 = BitConverter.ToInt32(rawBytes, subDataOffset + 12),
                                     I_16 = BitConverter.ToInt32(rawBytes, subDataOffset + 16),
@@ -70,9 +77,9 @@ namespace Xv2CoreLib.OCT
                                 subDataOffset += 24;
                                 break;
                             case 24:
-                                octFile.OctTableEntries[i].OctSubEntries.Add(new OCT_SubEntry()
+                                octFile.OctTableEntries[i].SubEntries.Add(new OCT_SubEntry()
                                 {
-                                    Index = BitConverter.ToInt32(rawBytes, subDataOffset + 4),
+                                    I_04 = BitConverter.ToInt32(rawBytes, subDataOffset + 4),
                                     I_08 = BitConverter.ToInt32(rawBytes, subDataOffset + 8),
                                     I_12 = BitConverter.ToInt32(rawBytes, subDataOffset + 12),
                                     STP_Cost = BitConverter.ToInt32(rawBytes, subDataOffset + 16),

--- a/Xv2CoreLib/PSO/PSO_File.cs
+++ b/Xv2CoreLib/PSO/PSO_File.cs
@@ -132,8 +132,19 @@ namespace Xv2CoreLib.PSO
 
     }
 
-    public class PSO_SubEntry
+    public class PSO_SubEntry : IInstallable
     {
+        #region Install
+        [YAXDontSerialize]
+        public string Index
+        {
+            set => I_00 = Utils.TryParseInt(value);
+            get => I_00.ToString();
+        }
+
+        [YAXDontSerialize]
+        public int SortID => I_00;
+        #endregion
         [YAXAttributeForClass]
         [YAXSerializeAs("ID")]
         public int I_00 { get; set; }


### PR DESCRIPTION
Adds installer support for OCT, PSO and OCP files using xml.

I did rename some values like Index > PartnerID, this will break some older files with serialization and I'm not too sure if there is a way to keep those compatible.

I also changed the uint to int for those, I'm also not sure if that matters a lot or not.

For OCT and OCP I copied most the code used for installing OCO files, for PSO I did the same but for ODF files.
If there's anything missing or anything that needs to be changed, please let me know.