### PR TITLE
Add functionality to install MSG xml files to all languages

### DIFF
--- a/LB Mod Installer/Installer/InstallerXml.cs
+++ b/LB Mod Installer/Installer/InstallerXml.cs
@@ -1056,6 +1056,11 @@ namespace LB_Mod_Installer.Installer
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = "True")]
         public string IsEnabled { get; set; }
 
+        // For MSG files
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = false)]
+        public bool InstallToAllLanguages { get; set; }
+
         //SkillDir
         [YAXAttributeForClass]
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = SkillType.NotSet)]
@@ -1124,7 +1129,8 @@ namespace LB_Mod_Installer.Installer
         AudioPackage,
         Binding,
         SkillDir,
-        EPatch
+        EPatch,
+        MSG
     }
 
     //Localisation

--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -742,7 +742,7 @@ namespace LB_Mod_Installer.Installer
             try
             {
                 MSG_File binaryFile = (MSG_File)GetParsedFile<MSG_File>(path, false);
-                MSG_File cpkBinFile = (MSG_File)GetParsedFile<MSG_File>(path, true);
+                MSG_File cpkBinFile = (MSG_File)GetParsedFile<MSG_File>(path, true, false);
 
                 Section section = file.GetSection(Sections.MSG_Entries);
 


### PR DESCRIPTION
I made this functionality among other things for the Revamp project. While I don't think the other additions to the installer I made are much needed for the main installer *(Such as showing the percentage of the installation progress instead of the files)*. I thought this one might be useful since adding msg files for every language to the installer can be a huge pain right now.

How it works:
```
    <File Type="MSG" InstallToAllLanguages="True">
      <SourcePath value="title_banner_text_en.msg.xml" />
      <InstallPath value="msg/title_banner_text_en.msg/>
    </File>
```

This will install the MSG file given in the SourcePath to whatever the InstallPath is, this is currently very sensitive as it checks in the InstallPath string for the "_en" (Or whatever other language there is) and strips it, then loops through every language suffix and appends that to the processed string (which in this example would be `title_banner_text_`).

A thing I'm not too sure about is the new File.Type specifically for this, however I couldn't find a way to implement this without needing to do a lot more edits to the code.

I understand if you don't want to implement this, but I've made this PR just in case.
There is also a fix for the installer not creating a MSG file when it didn't exist in the game or cache originally:
```
                if (binaryFile == null)
                {
                    binaryFile = new MSG_File
                    {
                        unicode_msg = xmlFile.unicode_msg,
                        unicode_names = xmlFile.unicode_names
                    };
                    fileManager.AddParsedFile(installPath, binaryFile);
                }
```