### PR TITLE
Add VLC parser and installer support

### DIFF
--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -55,6 +55,7 @@ using Xv2CoreLib.QED;
 using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
 using Xv2CoreLib.EEPK;
+using Xv2CoreLib.VLC;
 //using LB_Mod_Installer.Installer.Transformation;
 
 namespace LB_Mod_Installer.Installer
@@ -399,6 +400,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".bcm":
                     Install_BCM(xmlPath, installPath, isXml, useSkipBindings);
+                    break;
+                case ".vlc":
+                    Install_VLC(xmlPath, installPath, isXml, useSkipBindings);
                     break;
                 default:
                     //if (TryTransformationInstall(xmlPath))
@@ -1841,6 +1845,28 @@ namespace LB_Mod_Installer.Installer
 #endif
         }
 
+        private void Install_VLC(string xmlPath, string installPath, bool isXml, bool useSkipBindings)
+        {
+#if !DEBUG
+            try
+#endif
+            {
+                VLC_File xmlFile = (isXml) ? zipManager.DeserializeXmlFromArchive_Ext<VLC_File>(GeneralInfo.GetPathInZipDataDir(xmlPath)) : VLC_File.Parse(zipManager.GetFileFromArchive(GeneralInfo.GetPathInZipDataDir(xmlPath)));
+                VLC_File binaryFile = (VLC_File)GetParsedFile<VLC_File>(installPath);
+
+                //Install entries
+                InstallEntries(xmlFile.ZoomInCamera, binaryFile.ZoomInCamera, installPath, Sections.VLC_ZoomInCamera, useSkipBindings);
+                InstallEntries(xmlFile.UnkCamera, binaryFile.UnkCamera, installPath, Sections.VLC_UnkCamera, useSkipBindings);
+            }
+#if !DEBUG
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at VLC install phase ({0}).", xmlPath);
+                throw new Exception(error, ex);
+            }
+#endif
+        }
+
         private void Install_ERS(string xmlPath, string installPath, bool isXml, bool useSkipBindings)
         {
 #if !DEBUG
@@ -2485,6 +2511,8 @@ namespace LB_Mod_Installer.Installer
                     return TNN_File.Parse(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
                 case ".odf":
                     return ODF_File.Read(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
+                case ".vlc":
+                    return VLC_File.Parse(fileIO.GetFileFromGame(path, raiseEx, onlyFromCpk));
                 default:
                     throw new InvalidDataException(String.Format("GetParsedFileFromGame: The filetype of \"{0}\" is not supported.", path));
             }
@@ -2597,6 +2625,8 @@ namespace LB_Mod_Installer.Installer
                     return ((TNN_File)data).Write();
                 case ".odf":
                     return ((ODF_File)data).Write();
+                case ".vlc":
+                    return ((VLC_File)data).SaveToBytes();
                 case ".eepk":
                     return ((EEPK_File)data).SaveToBytes();
                 default:

--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -50,6 +50,7 @@ using Xv2CoreLib.QBT;
 using Xv2CoreLib.TNN;
 using Xv2CoreLib.ODF;
 using Xv2CoreLib.BCM;
+using Xv2CoreLib.VLC;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -324,6 +325,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".bcm":
                     Uninstall_BCM(path, file);
+                    break;
+                case ".vlc":
+                    Uninstall_VLC(path, file);
                     break;
                 default:
                     throw new Exception(string.Format("The filetype of \"{0}\" is unsupported. Uninstall failed.\n\nThis mod was likely installed by a newer version of the installer.", path));
@@ -1175,6 +1179,28 @@ namespace LB_Mod_Installer.Installer
             catch (Exception ex)
             {
                 string error = string.Format("Failed at CML uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
+
+        private void Uninstall_VLC(string path, _File file)
+        {
+            try
+            {
+                VLC_File binaryFile = (VLC_File)GetParsedFile<VLC_File>(path, false);
+                VLC_File cpkBinFile = (VLC_File)GetParsedFile<VLC_File>(path, true);
+
+                Section zoomInCameraSection = file.GetSection(Sections.VLC_ZoomInCamera);
+                Section unkCameraSection = file.GetSection(Sections.VLC_UnkCamera);
+
+                if (zoomInCameraSection != null)
+                    UninstallEntries(binaryFile.ZoomInCamera, (cpkBinFile != null) ? cpkBinFile.ZoomInCamera : null, zoomInCameraSection.IDs);
+                if (unkCameraSection != null)
+                    UninstallEntries(binaryFile.UnkCamera, (cpkBinFile != null) ? cpkBinFile.UnkCamera : null, unkCameraSection.IDs);
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at VLC uninstall phase ({0}).", path);
                 throw new Exception(error, ex);
             }
         }

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -71,6 +71,8 @@
         public const string OCO_Entry = "OCO_Entry";
         public const string QML_Entry = "QML_Entry";
         public const string CST_Entry = "CST_Entry";
+        public const string VLC_ZoomInCamera = "VLC_ZoomInCamera";
+        public const string VLC_UnkCamera = "VLC_UnkCamera";
         public const string CharaSlotEntry = "CharaSlotEntry";
         public const string StageSlotEntry = "StageSlotEntry";
         public const string StageDefEntry = "StageDefEntry";

--- a/XV2 Xml Serializer/Program.cs
+++ b/XV2 Xml Serializer/Program.cs
@@ -322,6 +322,9 @@ namespace XV2_Xml_Serializer
                                 case ".ems":
                                     Xv2CoreLib.EMS.EMS_File.CreateXml(fileLocation);
                                     break;
+                                case ".vlc":
+                                    Xv2CoreLib.VLC.VLC_File.Parse(fileLocation, true);
+                                    break;
                                 case ".xml":
                                     LoadXmlInitial(fileLocation);
                                     break;

--- a/XV2 Xml Serializer/Program.cs
+++ b/XV2 Xml Serializer/Program.cs
@@ -615,6 +615,9 @@ namespace XV2_Xml_Serializer
                     case ".ems":
                         Xv2CoreLib.EMS.EMS_File.SaveXml(fileLocation);
                         break;
+                    case ".vlc":
+                        Xv2CoreLib.VLC.VLC_File.Write(fileLocation);
+                        break;
                     default:
                         FileTypeNotSupported(fileLocation);
                         break;

--- a/Xv2CoreLib/VLC/VLC_File.cs
+++ b/Xv2CoreLib/VLC/VLC_File.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace Xv2CoreLib.VLC
+{
+    [YAXSerializeAs("VLC")]
+
+    public class VLC_File
+    {
+        [YAXCollection(YAXCollectionSerializationTypes.Recursive, EachElementName = "Camera")]
+        public List<VLC_Entry> ZoomInCamera { get; set; } = new List<VLC_Entry>();
+
+        [YAXCollection(YAXCollectionSerializationTypes.Recursive, EachElementName = "Camera")]
+        public List<VLC_Entry> UnkCamera { get; set; } = new List<VLC_Entry>();
+
+        #region LoadSave
+        public static VLC_File Parse(string path, bool writeXml)
+        {
+            VLC_File file = Parse(File.ReadAllBytes(path));
+
+            if (writeXml)
+            {
+                YAXSerializer serializer = new YAXSerializer(typeof(VLC_File));
+                serializer.SerializeToFile(file, path + ".xml");
+            }
+
+            return file;
+        }
+
+        public static VLC_File Parse(byte[] bytes)
+        {
+            VLC_File vlcFile = new VLC_File();
+            int numEntries = BitConverter.ToInt32(bytes, 0);
+            int offsetLeftCam = 16;
+            int offsetRightCam = offsetLeftCam + (numEntries * 16);
+            int entrySize = (int)((bytes.Length) / numEntries);
+
+            if (bytes.Length != 16 + (entrySize * numEntries))
+                throw new InvalidDataException($"Error on reading vlc file: Invalid file size!");
+
+            for(int i = 0; i < numEntries; i++)
+            {
+                vlcFile.ZoomInCamera.Add(new VLC_Entry()
+                {
+                    CharaId = (int)(BitConverter.ToSingle(bytes, offsetLeftCam + 12)),
+                    OffsetXYZ = new float[]
+                    {
+                        BitConverter.ToSingle(bytes, offsetLeftCam + 0),
+                        BitConverter.ToSingle(bytes, offsetLeftCam + 4),
+                        BitConverter.ToSingle(bytes, offsetLeftCam + 8)
+                    }
+                });
+
+                vlcFile.UnkCamera.Add(new VLC_Entry()
+                {
+                    CharaId = (int)(BitConverter.ToSingle(bytes, offsetRightCam + 12)),
+                    OffsetXYZ = new float[]
+                    {
+                        BitConverter.ToSingle(bytes, offsetRightCam + 0),
+                        BitConverter.ToSingle(bytes, offsetRightCam + 4),
+                        BitConverter.ToSingle(bytes, offsetRightCam + 8)
+                    }
+                });
+                offsetLeftCam += 16;
+                offsetRightCam += 16;
+            }
+
+            return vlcFile;
+        }
+
+        /// <summary>
+        /// Parse the xml at the specified path and convert it into a binary .vlc file, and save it at the same path minus the .xml.
+        /// </summary>
+        public static void Write(string xmlPath)
+        {
+            string saveLocation = String.Format("{0}/{1}", Path.GetDirectoryName(xmlPath), Path.GetFileNameWithoutExtension(xmlPath));
+            YAXSerializer serializer = new YAXSerializer(typeof(VLC_File), YAXSerializationOptions.DontSerializeNullObjects);
+            var vlcFile = (VLC_File)serializer.DeserializeFromFile(xmlPath);
+
+            File.WriteAllBytes(saveLocation, vlcFile.Write());
+        }
+
+        /// <summary>
+        /// Save the VLC_File to the specified path.
+        /// </summary>
+        /// <param name="path"></param>
+        public void Save(string path)
+        {
+            File.WriteAllBytes(path, Write());
+        }
+
+        public byte[] Write()
+        {
+            if (ZoomInCamera == null) ZoomInCamera = new List<VLC_Entry>();
+            if (UnkCamera == null) UnkCamera = new List<VLC_Entry>();
+
+            List<byte> bytes = new List<byte>();
+
+            //Offset / Padding
+            bytes.AddRange(BitConverter.GetBytes(16));
+            bytes.AddRange(BitConverter.GetBytes(16));
+            bytes.AddRange(BitConverter.GetBytes(16));
+            bytes.AddRange(BitConverter.GetBytes(16));
+
+            if (ZoomInCamera.Count != UnkCamera.Count)
+            {
+                throw new InvalidDataException($"Error on building vlc: CameraLeft and CameraLeft count mismatch!\nCameraLeft Count = " + ZoomInCamera.Count + "\nCameraRight Count = " + UnkCamera.Count);
+            }
+
+            //Entries
+            for (int i = 0; i < ZoomInCamera.Count; i++) // Using a for loop like this instead of foreach for the validation, cause we need the index
+            {
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[0]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[1]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[2]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].CharaId));
+
+                if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
+                    throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
+            }
+
+            for (int i = 0; i < UnkCamera.Count; i++)
+            {
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[0]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[1]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[2]));
+                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].CharaId));
+
+                if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
+                    throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
+            }
+
+            //validation
+            int validationAmount = 16 + (32 * ZoomInCamera.Count);
+            if (bytes.Count != 16 + (32 * ZoomInCamera.Count))
+                throw new InvalidDataException($"Error on building vlc: Invalid file size!");
+
+            return bytes.ToArray();
+        }
+
+        public byte[] SaveToBytes()
+        {
+            return Write();
+        }
+        #endregion
+    }
+
+    [YAXSerializeAs("Camera")]
+    public class VLC_Entry : IInstallable
+    {
+        #region NonSerialized
+
+        //interface
+        [YAXDontSerialize]
+        public int SortID { get { return CharaId; } }
+        [YAXDontSerialize]
+        public string Index
+        {
+            get
+            {
+                return $"{CharaId}_{OffsetXYZ[0]}_{OffsetXYZ[1]}_{OffsetXYZ[2]}";
+            }
+            set
+            {
+                string[] split = value.Split('_');
+
+                if (split.Length == 2)
+                {
+                    CharaId = int.Parse(split[0]);
+                    OffsetXYZ = new float[]
+                    {
+                        float.Parse(split[1]),
+                        float.Parse(split[2]),
+                        float.Parse(split[3])
+                    };
+                }
+            }
+        }
+        #endregion
+
+        [YAXAttributeForClass]
+        [YAXSerializeAs("CharaId")]
+        public int CharaId { get; set; } // Is actually a float
+
+        [YAXAttributeForClass]
+        [YAXCollection(YAXCollectionSerializationTypes.Serially, SeparateBy = ", ")]
+        [YAXSerializeAs("OffsetXYZ")]
+        public float[] OffsetXYZ { get; set; }
+    }
+}

--- a/Xv2CoreLib/VLC/VLC_File.cs
+++ b/Xv2CoreLib/VLC/VLC_File.cs
@@ -101,11 +101,11 @@ namespace Xv2CoreLib.VLC
 
             List<byte> bytes = new List<byte>();
 
-            //Offset / Padding
-            bytes.AddRange(BitConverter.GetBytes(16));
-            bytes.AddRange(BitConverter.GetBytes(16));
-            bytes.AddRange(BitConverter.GetBytes(16));
-            bytes.AddRange(BitConverter.GetBytes(16));
+            //Header
+            bytes.AddRange(BitConverter.GetBytes(ZoomInCamera.Count));
+            bytes.AddRange(BitConverter.GetBytes(0));
+            bytes.AddRange(BitConverter.GetBytes(0));
+            bytes.AddRange(BitConverter.GetBytes(0));
 
             if (ZoomInCamera.Count != UnkCamera.Count)
             {
@@ -118,7 +118,7 @@ namespace Xv2CoreLib.VLC
                 bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[0]));
                 bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[1]));
                 bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[2]));
-                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].CharaId));
+                bytes.AddRange(BitConverter.GetBytes((float)ZoomInCamera[i].CharaId));
 
                 if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
                     throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
@@ -126,10 +126,10 @@ namespace Xv2CoreLib.VLC
 
             for (int i = 0; i < UnkCamera.Count; i++)
             {
-                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[0]));
-                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[1]));
-                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].OffsetXYZ[2]));
-                bytes.AddRange(BitConverter.GetBytes(ZoomInCamera[i].CharaId));
+                bytes.AddRange(BitConverter.GetBytes(UnkCamera[i].OffsetXYZ[0]));
+                bytes.AddRange(BitConverter.GetBytes(UnkCamera[i].OffsetXYZ[1]));
+                bytes.AddRange(BitConverter.GetBytes(UnkCamera[i].OffsetXYZ[2]));
+                bytes.AddRange(BitConverter.GetBytes((float)UnkCamera[i].CharaId));
 
                 if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
                     throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
@@ -163,7 +163,7 @@ namespace Xv2CoreLib.VLC
         {
             get
             {
-                return $"{CharaId}_{OffsetXYZ[0]}_{OffsetXYZ[1]}_{OffsetXYZ[2]}";
+                return $"{CharaId}";
             }
             set
             {
@@ -172,12 +172,6 @@ namespace Xv2CoreLib.VLC
                 if (split.Length == 2)
                 {
                     CharaId = int.Parse(split[0]);
-                    OffsetXYZ = new float[]
-                    {
-                        float.Parse(split[1]),
-                        float.Parse(split[2]),
-                        float.Parse(split[3])
-                    };
                 }
             }
         }

--- a/Xv2CoreLib/VLC/VLC_File.cs
+++ b/Xv2CoreLib/VLC/VLC_File.cs
@@ -109,7 +109,7 @@ namespace Xv2CoreLib.VLC
 
             if (ZoomInCamera.Count != UnkCamera.Count)
             {
-                throw new InvalidDataException($"Error on building vlc: CameraLeft and CameraLeft count mismatch!\nCameraLeft Count = " + ZoomInCamera.Count + "\nCameraRight Count = " + UnkCamera.Count);
+                throw new InvalidDataException($"Error on building vlc: ZoomInCamera and UnkCamera count mismatch!\ZoomInCamera Count = " + ZoomInCamera.Count + "\UnkCamera Count = " + UnkCamera.Count);
             }
 
             //Entries
@@ -121,7 +121,7 @@ namespace Xv2CoreLib.VLC
                 bytes.AddRange(BitConverter.GetBytes((float)ZoomInCamera[i].CharaId));
 
                 if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
-                    throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
+                    throw new Exception("Chara ID mismatch at ZoomInCamera ID = " + ZoomInCamera[i].CharaId + "!\nUnkCamera ID = " + UnkCamera[i].CharaId);
             }
 
             for (int i = 0; i < UnkCamera.Count; i++)
@@ -132,7 +132,7 @@ namespace Xv2CoreLib.VLC
                 bytes.AddRange(BitConverter.GetBytes((float)UnkCamera[i].CharaId));
 
                 if (ZoomInCamera[i].CharaId != UnkCamera[i].CharaId)
-                    throw new Exception("Chara ID mismatch at CameraLeft ID = " + ZoomInCamera[i].CharaId + "!\nCameraRight ID = " + UnkCamera[i].CharaId);
+                    throw new Exception("Chara ID mismatch at ZoomInCamera ID = " + ZoomInCamera[i].CharaId + "!\nUnkCamera ID = " + UnkCamera[i].CharaId);
             }
 
             //validation

--- a/Xv2CoreLib/VLC/VLC_File.cs
+++ b/Xv2CoreLib/VLC/VLC_File.cs
@@ -109,7 +109,7 @@ namespace Xv2CoreLib.VLC
 
             if (ZoomInCamera.Count != UnkCamera.Count)
             {
-                throw new InvalidDataException($"Error on building vlc: ZoomInCamera and UnkCamera count mismatch!\ZoomInCamera Count = " + ZoomInCamera.Count + "\UnkCamera Count = " + UnkCamera.Count);
+                throw new InvalidDataException($"Error on building vlc: ZoomInCamera and UnkCamera count mismatch!\nZoomInCamera Count = " + ZoomInCamera.Count + "\nUnkCamera Count = " + UnkCamera.Count);
             }
 
             //Entries

--- a/Xv2CoreLib/Xv2CoreLib.csproj
+++ b/Xv2CoreLib/Xv2CoreLib.csproj
@@ -367,6 +367,7 @@
     <Compile Include="ValuesDictionary\BAC.cs" />
     <Compile Include="ValuesDictionary\BCS.cs" />
     <Compile Include="ValuesDictionary\EMP.cs" />
+    <Compile Include="VLC\VLC_File.cs" />
     <Compile Include="Xenoverse2\FileManager.cs" />
     <Compile Include="Xenoverse2\FileWatcher.cs" />
     <Compile Include="Xenoverse2\Xenoverse2.cs" />


### PR DESCRIPTION
Adds support for `vs_load_cam.vlc` files, `ZoomInCamera` is for the camera on the VS screen when it zooms in. `UnkCamera` is unknown where it's used but is in the file.

The amount of entries for `ZoomInCamera` and `UnkCamera` need to match, and there is validation for that.