### PR TITLE
fix msg file unicode bools on install

### DIFF
--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -1543,7 +1543,12 @@ namespace LB_Mod_Installer.Installer
 
                 if (binaryFile == null)
                 {
-                    binaryFile = new MSG_File(true);
+                    binaryFile = new MSG_File
+                    {
+                        //We need these both individually because there are cases where one can be false whilst the other is true
+                        unicode_msg = xmlFile.unicode_msg, 
+                        unicode_names = xmlFile.unicode_names
+                    };
                     fileManager.AddParsedFile(installPath, binaryFile);
                 }
 

--- a/Xv2CoreLib/MSG/MSG_File.cs
+++ b/Xv2CoreLib/MSG/MSG_File.cs
@@ -22,11 +22,6 @@ namespace Xv2CoreLib.MSG
 
         public MSG_File() { }
 
-        public MSG_File(bool unicode)
-        {
-            unicode_names = unicode_msg = unicode;
-        }
-
         public byte[] SaveToBytes()
         {
             return new Deserializer(this).bytes.ToArray();


### PR DESCRIPTION
Noticed an issue with this when I was testing some stuff with MSG file's. Apparently both unicode bools were set to true instead of taking them from the xmlFile, which caused some issues with dialogue in quests.