### PR TITLE
Update oco parser v1.22

### DIFF
--- a/Xv2CoreLib/OCO/Deserializer.cs
+++ b/Xv2CoreLib/OCO/Deserializer.cs
@@ -11,27 +11,30 @@ namespace Xv2CoreLib.OCO
     public class Deserializer
     {
         string saveLocation;
-        OCO_File octFile;
-        public List<byte> bytes = new List<byte>() { 35, 79, 67, 79, 254, 255, 16, 0 };
+        OCO_File ocoFile;
+        public List<byte> bytes = new List<byte>() { 35, 79, 67, 79, 254, 255 };
 
         public Deserializer(string location)
         {
             saveLocation = String.Format("{0}/{1}", Path.GetDirectoryName(location), Path.GetFileNameWithoutExtension(location));
             YAXSerializer serializer = new YAXSerializer(typeof(OCO_File), YAXSerializationOptions.DontSerializeNullObjects);
-            octFile = (OCO_File)serializer.DeserializeFromFile(location);
+            ocoFile = (OCO_File)serializer.DeserializeFromFile(location);
             Write();
             File.WriteAllBytes(saveLocation, bytes.ToArray());
         }
 
         public Deserializer(OCO_File ocoFile)
         {
-            this.octFile = ocoFile;
+            this.ocoFile = ocoFile;
             Write();
         }
 
         private void Write()
         {
-            int count = (octFile.Partners != null) ? octFile.Partners.Count() : 0;
+            // Header
+            VersionCheck();
+            bytes.AddRange(BitConverter.GetBytes(ocoFile.Version));
+            int count = (ocoFile.Partners != null) ? ocoFile.Partners.Count() : 0;
             bytes.AddRange(BitConverter.GetBytes(count));
             bytes.AddRange(new byte[4]);
 
@@ -41,28 +44,47 @@ namespace Xv2CoreLib.OCO
 
             for(int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.Partners[i].SubEntries != null) ? octFile.Partners[i].SubEntries.Count() : 0;
+                int subDataCount = (ocoFile.Partners[i].SubEntries != null) ? ocoFile.Partners[i].SubEntries.Count() : 0;
                 bytes.AddRange(BitConverter.GetBytes(subDataCount));
                 bytes.AddRange(BitConverter.GetBytes(dataOffset));
                 bytes.AddRange(BitConverter.GetBytes(currentIndex));
-                bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].PartnerID));
+                bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].PartnerID));
                 currentIndex += subDataCount;
             }
 
             //Table Entries
             for (int i = 0; i < count; i++)
             {
-                int subDataCount = (octFile.Partners[i].SubEntries != null) ? octFile.Partners[i].SubEntries.Count() : 0;
+                int subDataCount = (ocoFile.Partners[i].SubEntries != null) ? ocoFile.Partners[i].SubEntries.Count() : 0;
 
                 for(int a = 0; a < subDataCount; a++)
                 {
-                    bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].PartnerID));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].SubEntries[a].I_04));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].SubEntries[a].I_08));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].SubEntries[a].I_12));
-                    bytes.AddRange(BitConverter.GetBytes(octFile.Partners[i].SubEntries[a].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].PartnerID));
+                    bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].SubEntries[a].I_04));
+                    bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].SubEntries[a].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].SubEntries[a].I_12));
+
+                    if (ocoFile.Version >= 20)
+                    {
+                        bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].SubEntries[a].NEW_I_16));
+                    }
+
+                    bytes.AddRange(BitConverter.GetBytes(ocoFile.Partners[i].SubEntries[a].I_16));
                 }
 
+            }
+
+        }
+
+        private void VersionCheck()
+        {
+            switch (ocoFile.Version)
+            {
+                case 16:
+                case 20:
+                    return;
+                default:
+                    throw new Exception("Unknown OCO version: " + ocoFile.Version);
             }
 
         }

--- a/Xv2CoreLib/OCO/OCO_File.cs
+++ b/Xv2CoreLib/OCO/OCO_File.cs
@@ -8,6 +8,9 @@ namespace Xv2CoreLib.OCO
     [YAXSerializeAs("OCO")]
     public class OCO_File
     {
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 16)]
+        public ushort Version { get; set; } // 16 = pre 1.22, 20 = 1.22 or later
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Partner")]
         public List<OCO_Partner> Partners { get; set; }
 
@@ -63,6 +66,10 @@ namespace Xv2CoreLib.OCO
         [YAXAttributeForClass]
         [YAXSerializeAs("I_12")]
         public int I_12 { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("NEW_I_16")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
+        public int NEW_I_16 { get; set; } //Added in v1.22
         [YAXAttributeForClass]
         [YAXSerializeAs("PartSet")]
         public int I_16 { get; set; }

--- a/Xv2CoreLib/OCP/OCP_File.cs
+++ b/Xv2CoreLib/OCP/OCP_File.cs
@@ -7,6 +7,7 @@ namespace Xv2CoreLib.OCP
     public class OCP_File
     {
         [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 16)]
         public ushort Version { get; set; } // 16 = pre 1.22, 20 = 1.22 or later
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Partner")]
         public List<OCP_TableEntry> TableEntries { get; set; }


### PR DESCRIPTION
Updates the parser for oco files for the new version 1.22 format.
Also adds a version check

It's possible there is more formats that were updated, that were missed. If I find any I'll update those as well.