### PR TITLE
installer: fix "how" msgcomponent install bug

### DIFF
--- a/LB Mod Installer/Installer/Install.cs
+++ b/LB Mod Installer/Installer/Install.cs
@@ -2437,7 +2437,7 @@ namespace LB_Mod_Installer.Installer
                     }
                     else if (msgComponent.MsgType == Msg_Component.MsgComponentType.How)
                     {
-                        if(!filePath.Equals("talisman_item.idb", StringComparison.OrdinalIgnoreCase))
+                        if(!filePath.Contains("talisman_item.idb"))
                         {
                             throw new Exception("The \"How\" MsgComponent can only be used talisman_item.idb.");
                         }


### PR DESCRIPTION
With the old if check, you couldn't install the file if the install path was for example `system/item/talisman_item.idb`