### PR TITLE
Add cdt file parser and installer

### DIFF
--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -56,6 +56,7 @@ using Xv2CoreLib.OCT;
 using Xv2CoreLib.PSO;
 using Xv2CoreLib.OCP;
 using Xv2CoreLib.AIT;
+using Xv2CoreLib.CDT;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -348,6 +349,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".ait":
                     Uninstall_AIT(path, file);
+                    break;
+                case ".cdt":
+                    Uninstall_CDT(path, file);
                     break;
                 default:
                     throw new Exception(string.Format("The filetype of \"{0}\" is unsupported. Uninstall failed.\n\nThis mod was likely installed by a newer version of the installer.", path));
@@ -1714,6 +1718,24 @@ namespace LB_Mod_Installer.Installer
             catch (Exception ex)
             {
                 string error = string.Format("Failed at BCM uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
+
+        private void Uninstall_CDT(string path, _File file)
+        {
+            try
+            {
+                CDT_File binaryFile = (CDT_File)GetParsedFile<CDT_File>(path, false);
+                CDT_File cpkBinFile = (CDT_File)GetParsedFile<CDT_File>(path, true);
+
+                Section section = file.GetSection(Sections.CDT_Entry);
+
+                UninstallEntries(binaryFile.Entries, (cpkBinFile != null) ? cpkBinFile.Entries : null, section.IDs);
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at CDT uninstall phase ({0}).", path);
                 throw new Exception(error, ex);
             }
         }

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -75,9 +75,10 @@
         public const string OCP_Entry = "OCP_Entry";
         public const string QML_Entry = "QML_Entry";
         public const string CST_Entry = "CST_Entry";
+        public const string AIT_Entry = "AIT_Entry";
+        public const string CDT_Entry = "CDT_Entry";
         public const string VLC_ZoomInCamera = "VLC_ZoomInCamera";
         public const string VLC_UnkCamera = "VLC_UnkCamera";
-        public const string AIT_Entry = "AIT_Entry";
         public const string CharaSlotEntry = "CharaSlotEntry";
         public const string StageSlotEntry = "StageSlotEntry";
         public const string StageDefEntry = "StageDefEntry";

--- a/XV2 Xml Serializer/Program.cs
+++ b/XV2 Xml Serializer/Program.cs
@@ -328,6 +328,9 @@ namespace XV2_Xml_Serializer
                                 case ".vlc":
                                     Xv2CoreLib.VLC.VLC_File.Parse(fileLocation, true);
                                     break;
+                                case ".cdt":
+                                    new Xv2CoreLib.CDT.Parser(fileLocation, true);
+                                    break;
                                 case ".xml":
                                     LoadXmlInitial(fileLocation);
                                     break;
@@ -622,6 +625,9 @@ namespace XV2_Xml_Serializer
                         break;
                     case ".vlc":
                         Xv2CoreLib.VLC.VLC_File.Write(fileLocation);
+                        break;
+                    case ".cdt":
+                        new Xv2CoreLib.CDT.Deserializer(fileLocation);
                         break;
                     default:
                         FileTypeNotSupported(fileLocation);

--- a/Xv2CoreLib/CDT/CDT_File.cs
+++ b/Xv2CoreLib/CDT/CDT_File.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YAXLib;
+
+namespace Xv2CoreLib.CDT
+{
+    [YAXSerializeAs("CDT")]
+    public class CDT_File
+    {
+        [YAXAttributeForClass]
+        public uint I_08 { get; set; }
+        [YAXAttributeForClass]
+        public uint I_12 { get; set; }
+        [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Entry")]
+        public List<CDT_Entry> Entries { get; set; }
+
+        #region LoadSave
+        public static CDT_File Load(byte[] bytes)
+        {
+            return new Parser(bytes).cdtFile;
+        }
+
+        public byte[] SaveToBytes()
+        {
+            return new Deserializer(this).bytes.ToArray();
+        }
+        #endregion
+    }
+
+    [YAXSerializeAs("Entry")]
+    public class CDT_Entry : IInstallable
+    {
+        #region Installer
+        [YAXDontSerialize]
+        public int SortID { get { return ID; } set { ID = value; } }
+        [YAXDontSerialize]
+        public string Index { get { return ID.ToString(); } set { ID = Utils.TryParseInt(value); } }
+        #endregion
+
+        [YAXAttributeForClass]
+        [YAXSerializeAs("ID")]
+        public int ID { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("TextLeftLength")]
+        [YAXDontSerialize]
+        public int TextLeftLength { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("TextLeft")]
+        public string TextLeft { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("TextRightLength")]
+        [YAXDontSerialize]
+        public int TextRightLength { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("TextRight")]
+        public string TextRight { get; set; }
+        //These ints do many different things like text align, padding, but also control images that show in the credits
+        [YAXAttributeFor("I_16")]
+        [YAXSerializeAs("value")]
+        public int I_16 { get; set; }
+        [YAXAttributeFor("I_20")]
+        [YAXSerializeAs("value")]
+        public int I_20 { get; set; }
+        [YAXAttributeFor("I_24")]
+        [YAXSerializeAs("value")]
+        public int I_24 { get; set; }
+    }
+}

--- a/Xv2CoreLib/CDT/CDT_File.cs
+++ b/Xv2CoreLib/CDT/CDT_File.cs
@@ -9,6 +9,10 @@ namespace Xv2CoreLib.CDT
     public class CDT_File
     {
         [YAXAttributeForClass]
+        [YAXDontSerializeIfNull]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
+        public bool Reindex { get; set; } = false; // Boolean that "reindexes" the file so we can add entries anywhere without worrying about the ID
+        [YAXAttributeForClass]
         public uint I_08 { get; set; }
         [YAXAttributeForClass]
         public uint I_12 { get; set; }
@@ -33,14 +37,15 @@ namespace Xv2CoreLib.CDT
     {
         #region Installer
         [YAXDontSerialize]
-        public int SortID { get { return ID; } set { ID = value; } }
+        public int SortID { get { return int.Parse(ID); } set { ID = value.ToString(); } }
         [YAXDontSerialize]
-        public string Index { get { return ID.ToString(); } set { ID = Utils.TryParseInt(value); } }
+        public string Index { get { return ID.ToString(); } set { ID = value.ToString(); } }
         #endregion
 
         [YAXAttributeForClass]
         [YAXSerializeAs("ID")]
-        public int ID { get; set; }
+        [BindingAutoId]
+        public string ID { get; set; } //uint32
         [YAXAttributeForClass]
         [YAXSerializeAs("TextLeftLength")]
         [YAXDontSerialize]

--- a/Xv2CoreLib/CDT/Deserializer.cs
+++ b/Xv2CoreLib/CDT/Deserializer.cs
@@ -41,7 +41,7 @@ namespace Xv2CoreLib.CDT
             {
                 for (int i = 0; i < count; i++)
                 {
-                    bytes.AddRange(BitConverter.GetBytes(i));
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Reindex ? i : int.Parse(cdtFile.Entries[i].ID)));
                     if (cdtFile.Entries[i].TextLeft == null) cdtFile.Entries[i].TextLeft = string.Empty;
                     bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].TextLeft.Length * 2 + 2));
                     bytes.AddRange(Encoding.Unicode.GetBytes(cdtFile.Entries[i].TextLeft));

--- a/Xv2CoreLib/CDT/Deserializer.cs
+++ b/Xv2CoreLib/CDT/Deserializer.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace Xv2CoreLib.CDT
+{
+    public class Deserializer
+    {
+        string saveLocation;
+        CDT_File cdtFile;
+        public List<byte> bytes = new List<byte>() { 35, 67, 68, 84 };
+
+        public Deserializer(string location)
+        {
+            saveLocation = String.Format("{0}/{1}", Path.GetDirectoryName(location), Path.GetFileNameWithoutExtension(location));
+            YAXSerializer serializer = new YAXSerializer(typeof(CDT_File), YAXSerializationOptions.DontSerializeNullObjects);
+            cdtFile = (CDT_File)serializer.DeserializeFromFile(location);
+            Write();
+            File.WriteAllBytes(saveLocation, bytes.ToArray());
+        }
+
+        public Deserializer(CDT_File cdtFile)
+        {
+            this.cdtFile = cdtFile;
+            Write();
+        }
+
+        private void Write()
+        {
+            // Header
+            int count = (cdtFile.Entries != null) ? cdtFile.Entries.Count() : 0;
+            bytes.AddRange(BitConverter.GetBytes(count));
+            bytes.AddRange(BitConverter.GetBytes(cdtFile.I_08));
+            bytes.AddRange(BitConverter.GetBytes(cdtFile.I_12));
+
+            if (count > 0)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(i));
+                    if (cdtFile.Entries[i].TextLeft == null) cdtFile.Entries[i].TextLeft = string.Empty;
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].TextLeft.Length * 2 + 2));
+                    bytes.AddRange(Encoding.Unicode.GetBytes(cdtFile.Entries[i].TextLeft));
+                    bytes.AddRange(new byte[2]);
+                    if (cdtFile.Entries[i].TextRight == null) cdtFile.Entries[i].TextRight = string.Empty;
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].TextRight.Length * 2 + 2));
+                    bytes.AddRange(Encoding.Unicode.GetBytes(cdtFile.Entries[i].TextRight));
+                    bytes.AddRange(new byte[2]);
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].I_20));
+                    bytes.AddRange(BitConverter.GetBytes(cdtFile.Entries[i].I_24));
+                }
+            }
+        }
+    }
+}

--- a/Xv2CoreLib/CDT/Parser.cs
+++ b/Xv2CoreLib/CDT/Parser.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace Xv2CoreLib.CDT
+{
+    public class Parser
+    {
+        private string saveLocation;
+        private byte[] rawBytes;
+        public CDT_File cdtFile { get; private set; } = new CDT_File();
+
+        public Parser(string path, bool _writeXml)
+        {
+            saveLocation = path;
+            rawBytes = File.ReadAllBytes(path);
+
+            Parse();
+
+            if (_writeXml)
+            {
+                YAXSerializer serializer = new YAXSerializer(typeof(CDT_File));
+                serializer.SerializeToFile(cdtFile, saveLocation + ".xml");
+            }
+        }
+
+        public Parser(byte[] bytes)
+        {
+            rawBytes = bytes;
+
+            Parse();
+        }
+
+        private void Parse()
+        {
+            uint count = BitConverter.ToUInt32(rawBytes, 4);
+            cdtFile.I_08 = BitConverter.ToUInt32(rawBytes, 8);
+            cdtFile.I_12 = BitConverter.ToUInt32(rawBytes, 12);
+            int offset = 16;
+
+            if (count > 0)
+            {
+                cdtFile.Entries = new List<CDT_Entry>();
+
+                for(int i = 0; i < count; i++)
+                {
+                    cdtFile.Entries.Add(new CDT_Entry() { ID = BitConverter.ToInt32(rawBytes, offset) });
+
+                    cdtFile.Entries[i].TextLeftLength = BitConverter.ToInt32(rawBytes, offset + 4);
+                    cdtFile.Entries[i].TextLeft = StringEx.GetString(rawBytes, offset + 8, false, StringEx.EncodingType.Unicode, (int)cdtFile.Entries[i].TextLeftLength);
+                    offset += (int)cdtFile.Entries[i].TextLeftLength - 2;
+                    cdtFile.Entries[i].TextRightLength = BitConverter.ToInt32(rawBytes, (int)(offset + 10));
+                    cdtFile.Entries[i].TextRight = StringEx.GetString(rawBytes, offset + 14, false, StringEx.EncodingType.Unicode, (int)cdtFile.Entries[i].TextRightLength);
+                    offset += (int)cdtFile.Entries[i].TextRightLength - 2;
+                    cdtFile.Entries[i].I_16 = BitConverter.ToInt32(rawBytes, offset + 16);
+                    cdtFile.Entries[i].I_20 = BitConverter.ToInt32(rawBytes, offset + 20);
+                    cdtFile.Entries[i].I_24 = BitConverter.ToInt32(rawBytes, offset + 24);
+
+                    offset += 28;
+                }
+            }
+        }
+    }
+}

--- a/Xv2CoreLib/CDT/Parser.cs
+++ b/Xv2CoreLib/CDT/Parser.cs
@@ -48,7 +48,7 @@ namespace Xv2CoreLib.CDT
 
                 for(int i = 0; i < count; i++)
                 {
-                    cdtFile.Entries.Add(new CDT_Entry() { ID = BitConverter.ToInt32(rawBytes, offset) });
+                    cdtFile.Entries.Add(new CDT_Entry() { ID = BitConverter.ToInt32(rawBytes, offset).ToString() });
 
                     cdtFile.Entries[i].TextLeftLength = BitConverter.ToInt32(rawBytes, offset + 4);
                     cdtFile.Entries[i].TextLeft = StringEx.GetString(rawBytes, offset + 8, false, StringEx.EncodingType.Unicode, (int)cdtFile.Entries[i].TextLeftLength);

--- a/Xv2CoreLib/Xv2CoreLib.csproj
+++ b/Xv2CoreLib/Xv2CoreLib.csproj
@@ -268,6 +268,9 @@
     <Compile Include="OCC\Deserializer.cs" />
     <Compile Include="OCC\OCC_File.cs" />
     <Compile Include="OCC\Parser.cs" />
+    <Compile Include="CDT\Deserializer.cs" />
+    <Compile Include="CDT\CDT_File.cs" />
+    <Compile Include="CDT\Parser.cs" />
     <Compile Include="OCO\Deserializer.cs" />
     <Compile Include="OCO\OCO_File.cs" />
     <Compile Include="OCO\Parser.cs" />


### PR DESCRIPTION
Adds support for CDT files (for example `credit_eu.cdt`), which control the game's credits.

Still unknown what the header values do, but I serialize them just in case it's something important