### PR TITLE
Quick hack for GetEntry

### DIFF
--- a/LB Mod Installer/Binding/BindingManager.cs
+++ b/LB Mod Installer/Binding/BindingManager.cs
@@ -446,6 +446,7 @@ namespace LB_Mod_Installer.Binding
                         case Function.GetEntry:
                             {
                                 string alias = b.GetArgument1();
+                                string alias2 = b.GetArgument1() + "_event";
 
                                 if(CurrentEntry is TSD_Trigger trigger)
                                 {
@@ -454,6 +455,7 @@ namespace LB_Mod_Installer.Binding
                                     if(entry != null)
                                     {
                                         AddAlias(entry.SortID.ToString(), alias);
+                                       AddAlias(entry.I_24.ToString(), alias2);
 
                                         //Entry will be removed and not installed
                                         retID = NullTokenInt;

--- a/Xv2CoreLib/TSD/TSD_File.cs
+++ b/Xv2CoreLib/TSD/TSD_File.cs
@@ -86,7 +86,6 @@ namespace Xv2CoreLib.TSD
             if (I_12 != trigger.I_12) return false;
             if (I_16 != trigger.I_16) return false;
             if (I_20 != trigger.I_20) return false;
-            if (I_24 != trigger.I_24) return false;
             if (I_28 != trigger.I_28) return false;
             if (Condition != trigger.Condition) return false;
 


### PR DESCRIPTION
-Removed compare of Event_ID
-Added second alias to GetEntry copying the Event ID value
    Second alias named the same as first alias but appended _event
    
Not the most elegant solution, but it makes GetEntry way more useful for those that use it (namely only me, I guess)