### PR TITLE
add: installer support for FMP files

### DIFF
--- a/LB Mod Installer/Installer/Uninstall.cs
+++ b/LB Mod Installer/Installer/Uninstall.cs
@@ -58,6 +58,7 @@ using Xv2CoreLib.OCP;
 using Xv2CoreLib.AIT;
 using Xv2CoreLib.CDT;
 using Xv2CoreLib.SDS;
+using Xv2CoreLib.FMP;
 
 namespace LB_Mod_Installer.Installer
 {
@@ -353,6 +354,9 @@ namespace LB_Mod_Installer.Installer
                     break;
                 case ".cdt":
                     Uninstall_CDT(path, file);
+                    break;
+                case ".map":
+                    Uninstall_FMP(path, file);
                     break;
                 case ".emz":
                     //The normal file loading methods are problematic for emz, since it can technically be multiple different files.
@@ -1787,6 +1791,31 @@ namespace LB_Mod_Installer.Installer
             }
         }
 
+        private void Uninstall_FMP(string path, _File file)
+        {
+            try
+            {
+                FMP_File binaryFile = (FMP_File)GetParsedFile<FMP_File>(path, false);
+                FMP_File cpkBinFile = (FMP_File)GetParsedFile<FMP_File>(path, true);
+
+                Section fragmentGroups = file.GetSection(Sections.FMP_FragmentGroup);
+                Section hitboxGroups = file.GetSection(Sections.FMP_HitboxGroup);
+                Section objects = file.GetSection(Sections.FMP_ObjectEntry);
+                Section section1 = file.GetSection(Sections.FMP_Section1Entry);
+                Section section2 = file.GetSection(Sections.FMP_Section2Entry);
+
+                UninstallEntries(binaryFile.FragmentGroups, (cpkBinFile != null) ? cpkBinFile.FragmentGroups : null, fragmentGroups.IDs);
+                UninstallEntries(binaryFile.HitboxGroups, (cpkBinFile != null) ? cpkBinFile.HitboxGroups : null, hitboxGroups.IDs);
+                UninstallEntries(binaryFile.Objects, (cpkBinFile != null) ? cpkBinFile.Objects : null, objects.IDs);
+                UninstallEntries(binaryFile.Section1List, (cpkBinFile != null) ? cpkBinFile.Section1List : null, section1.IDs);
+                UninstallEntries(binaryFile.Section2List, (cpkBinFile != null) ? cpkBinFile.Section2List : null, section2.IDs);
+            }
+            catch (Exception ex)
+            {
+                string error = string.Format("Failed at FMP uninstall phase ({0}).", path);
+                throw new Exception(error, ex);
+            }
+        }
 
         //Generic uninstallers
         private void UninstallEntries<T>(IList<T> entries, IList<T> ogEntries, List<string> ids) where T : IInstallable

--- a/LB Mod Installer/Tracking/Sections.cs
+++ b/LB Mod Installer/Tracking/Sections.cs
@@ -77,6 +77,11 @@
         public const string CST_Entry = "CST_Entry";
         public const string AIT_Entry = "AIT_Entry";
         public const string CDT_Entry = "CDT_Entry";
+        public const string FMP_Section1Entry = "FMP_Section1Entry";
+        public const string FMP_Section2Entry = "FMP_Section2Entry";
+        public const string FMP_FragmentGroup = "FMP_FragmentGroup";
+        public const string FMP_ObjectEntry = "FMP_ObjectEntry";
+        public const string FMP_HitboxGroup = "FMP_HitboxGroup";
         public const string VLC_ZoomInCamera = "VLC_ZoomInCamera";
         public const string VLC_UnkCamera = "VLC_UnkCamera";
         public const string SDS_ShaderProgram = "SDS_ShaderProgram";

--- a/Xv2CoreLib/FMP/FMP_File.cs
+++ b/Xv2CoreLib/FMP/FMP_File.cs
@@ -613,10 +613,14 @@ namespace Xv2CoreLib.FMP
         }
     }
 
-    public class FMP_Section1
+    public class FMP_Section1 : IInstallable
     {
+        [YAXDontSerialize]
+        public int SortID { get { return 0; } } // No sorting is done for this type, but we must define a SortID regardless
+
+        [YAXSerializeAs("Name")]
         [YAXAttributeForClass]
-        public string Name { get; set; }
+        public string Index { get; set; }
 
         [CustomSerialize]
         public int I_04 { get; set; }
@@ -641,7 +645,7 @@ namespace Xv2CoreLib.FMP
         {
             List<byte> bytes = new List<byte>();
 
-            stringWriter.Add(new StringWriter.StringInfo() { Offset = fileSize, StringToWrite = Name });
+            stringWriter.Add(new StringWriter.StringInfo() { Offset = fileSize, StringToWrite = Index });
             bytes.AddRange(new byte[4]);
             bytes.AddRange(BitConverter.GetBytes(I_04));
             bytes.AddRange(BitConverter.GetBytes(F_08));
@@ -671,7 +675,7 @@ namespace Xv2CoreLib.FMP
         {
             return new FMP_Section1()
             {
-                Name = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset)),
+                Index = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset)),
                 I_04 = BitConverter.ToInt32(bytes, offset + 4),
                 F_08 = BitConverter.ToSingle(bytes, offset + 8),
                 F_12 = BitConverter.ToSingle(bytes, offset + 12),
@@ -681,10 +685,14 @@ namespace Xv2CoreLib.FMP
         }
     }
 
-    public class FMP_Section2
+    public class FMP_Section2 : IInstallable
     {
+        [YAXDontSerialize]
+        public int SortID { get { return 0; } } // No sorting is done for this type, but we must define a SortID regardless
+
+        [YAXSerializeAs("Name")]
         [YAXAttributeForClass]
-        public string Name { get; set; }
+        public string Index { get; set; }
 
         [CustomSerialize(isFloat: true)]
         public float F_04 { get; set; }
@@ -711,7 +719,7 @@ namespace Xv2CoreLib.FMP
         {
             List<byte> bytes = new List<byte>();
 
-            stringWriter.Add(new StringWriter.StringInfo() { Offset = fileSize, StringToWrite = Name });
+            stringWriter.Add(new StringWriter.StringInfo() { Offset = fileSize, StringToWrite = Index });
             bytes.AddRange(new byte[4]);
             bytes.AddRange(BitConverter.GetBytes(F_04));
             bytes.AddRange(BitConverter.GetBytes(F_08));
@@ -742,7 +750,7 @@ namespace Xv2CoreLib.FMP
         {
             return new FMP_Section2()
             {
-                Name = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset)),
+                Index = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset)),
                 F_04 = BitConverter.ToSingle(bytes, offset + 4),
                 F_08 = BitConverter.ToSingle(bytes, offset + 8),
                 F_12 = BitConverter.ToSingle(bytes, offset + 12),
@@ -753,10 +761,14 @@ namespace Xv2CoreLib.FMP
         }
     }
 
-    public class FMP_FragmentGroup
+    public class FMP_FragmentGroup : IInstallable
     {
+        [YAXDontSerialize]
+        public int SortID { get { return 0; } } // No sorting is done for this type, but we must define a SortID regardless
+
+        [YAXSerializeAs("Name")]
         [YAXAttributeForClass]
-        public string Name { get; set; }
+        public string Index { get; set; }
 
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "ObjectIndex")]
         [YAXAttributeFor("ObjectIndex")]
@@ -769,7 +781,7 @@ namespace Xv2CoreLib.FMP
             //Main body, 12 bytes each
             for (int i = 0; i < entries.Count; i++)
             {
-                stringWriter.Add(new StringWriter.StringInfo() { Offset = bytes.Count, StringToWrite = entries[i].Name });
+                stringWriter.Add(new StringWriter.StringInfo() { Offset = bytes.Count, StringToWrite = entries[i].Index });
                 bytes.AddRange(new byte[4]);
                 bytes.AddRange(BitConverter.GetBytes(entries[i].Indices != null ? entries[i].Indices.Count : 0));
                 bytes.AddRange(new byte[4]);
@@ -809,7 +821,7 @@ namespace Xv2CoreLib.FMP
         public static FMP_FragmentGroup Read(byte[] bytes, int offset)
         {
             FMP_FragmentGroup fragmentGroup = new FMP_FragmentGroup();
-            fragmentGroup.Name = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset));
+            fragmentGroup.Index = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset));
 
             int indexCount = BitConverter.ToInt32(bytes, offset + 4);
             int indexOffset = BitConverter.ToInt32(bytes, offset + 8);
@@ -831,10 +843,14 @@ namespace Xv2CoreLib.FMP
     }
 
     [YAXSerializeAs("Object")]
-    public class FMP_Object
+    public class FMP_Object : IInstallable
     {
+        [YAXDontSerialize]
+        public int SortID { get { return 0; } } // No sorting is done for this type, but we must define a SortID regardless
+
+        [YAXSerializeAs("Name")]
         [YAXAttributeForClass]
-        public string Name { get; set; }
+        public string Index { get; set; }
 
         [CustomSerialize(isHex: true)]
         public int I_04 { get; set; }
@@ -865,7 +881,7 @@ namespace Xv2CoreLib.FMP
             //Write main Object entries
             for(int i = 0; i < objects.Count; i++)
             {
-                stringWriter.Add(new StringWriter.StringInfo() { Offset = bytes.Count, StringToWrite = objects[i].Name });
+                stringWriter.Add(new StringWriter.StringInfo() { Offset = bytes.Count, StringToWrite = objects[i].Index });
                 bytes.AddRange(new byte[4]);
                 bytes.AddRange(BitConverter.GetBytes(objects[i].I_04));
                 bytes.AddRange(BitConverter.GetBytes(objects[i].HitboxGroupIndex));
@@ -985,7 +1001,7 @@ namespace Xv2CoreLib.FMP
         public static FMP_Object Read(byte[] bytes, int offset, string[] depot1, string[] depot2, string[] depot3, string[] depot4, FMP_File fmpFile)
         {
             FMP_Object obj = new FMP_Object();
-            obj.Name = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset));
+            obj.Index = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset));
             obj.I_04 = BitConverter.ToInt32(bytes, offset + 4);
             obj.HitboxGroupIndex = BitConverter.ToUInt16(bytes, offset + 8);
             obj.I_10 = BitConverter.ToUInt16(bytes, offset + 10);
@@ -2217,10 +2233,15 @@ namespace Xv2CoreLib.FMP
     }
 
     [YAXSerializeAs("HitboxGroup")]
-    public class FMP_HitboxGroup
+    public class FMP_HitboxGroup : IInstallable
     {
+        [YAXDontSerialize]
+        public int SortID { get { return int.Parse(Index); } }
+
         [YAXAttributeForClass]
-        public int Index { get; set; }
+        [BindingAutoId()]
+        public string Index { get; set; }
+
         [YAXAttributeForClass]
         public string Name { get; set; }
 
@@ -2351,7 +2372,7 @@ namespace Xv2CoreLib.FMP
         public static FMP_HitboxGroup Read(byte[] bytes, int offset, int index, bool oldVersion)
         {
             FMP_HitboxGroup hitboxGroup = new FMP_HitboxGroup();
-            hitboxGroup.Index = index;
+            hitboxGroup.Index = index.ToString();
             hitboxGroup.Name = StringEx.GetString(bytes, BitConverter.ToInt32(bytes, offset));
 
             int hitboxCount = BitConverter.ToInt32(bytes, offset + 4);

--- a/Xv2CoreLib/FMP/FMP_File.cs
+++ b/Xv2CoreLib/FMP/FMP_File.cs
@@ -2624,11 +2624,12 @@ namespace Xv2CoreLib.FMP
         [CustomSerialize(isFloat: true)]
         public float Roll { get; set; }
         [CustomSerialize(isFloat: true)]
-        public float F_28 { get; set; }
+        public float ScaleX { get; set; } // F_28
         [CustomSerialize(isFloat: true)]
-        public float F_32 { get; set; }
+        public float ScaleY { get; set; } // F_32
         [CustomSerialize(isFloat: true)]
-        public float F_36 { get; set; }
+        // For some reason YAXAttributeFor doesn't work for F_36
+        public float ScaleZ { get; set; } // F_36
         [CustomSerialize(isFloat: true)]
         public float F_40 { get; set; }
         [CustomSerialize(isFloat: true)]
@@ -2649,9 +2650,9 @@ namespace Xv2CoreLib.FMP
             bytes.AddRange(BitConverter.GetBytes(Yaw));
             bytes.AddRange(BitConverter.GetBytes(Pitch));
             bytes.AddRange(BitConverter.GetBytes(Roll));
-            bytes.AddRange(BitConverter.GetBytes(F_28));
-            bytes.AddRange(BitConverter.GetBytes(F_32));
-            bytes.AddRange(BitConverter.GetBytes(F_36));
+            bytes.AddRange(BitConverter.GetBytes(ScaleX));
+            bytes.AddRange(BitConverter.GetBytes(ScaleY));
+            bytes.AddRange(BitConverter.GetBytes(ScaleZ));
             bytes.AddRange(BitConverter.GetBytes(F_40));
             bytes.AddRange(BitConverter.GetBytes(F_44));
             bytes.AddRange(BitConverter.GetBytes(F_48));
@@ -2674,9 +2675,9 @@ namespace Xv2CoreLib.FMP
                 Yaw = BitConverter.ToSingle(bytes, offset + 16),
                 Pitch = BitConverter.ToSingle(bytes, offset + 20),
                 Roll = BitConverter.ToSingle(bytes, offset + 24),
-                F_28 = BitConverter.ToSingle(bytes, offset + 28),
-                F_32 = BitConverter.ToSingle(bytes, offset + 32),
-                F_36 = BitConverter.ToSingle(bytes, offset + 36),
+                ScaleX = BitConverter.ToSingle(bytes, offset + 28),
+                ScaleY = BitConverter.ToSingle(bytes, offset + 32),
+                ScaleZ = BitConverter.ToSingle(bytes, offset + 36),
                 F_40 = BitConverter.ToSingle(bytes, offset + 40),
                 F_44 = BitConverter.ToSingle(bytes, offset + 44),
                 F_48 = BitConverter.ToSingle(bytes, offset + 48),


### PR DESCRIPTION
adds installer support for FMP (.map) files

Currently supports entries for:

- Section1
- Section2
- FragmentGroups
- HitboxGroups
- Objects