### PR TITLE
Update formats for v1.25

### DIFF
--- a/XV2 Xml Serializer/Program.cs
+++ b/XV2 Xml Serializer/Program.cs
@@ -25,7 +25,7 @@ namespace XV2_Xml_Serializer
         {
 #if DEBUG
             //for debugging only
-            //args = new string[1] { @"test.map.xml" };
+            args = new string[1] { @"E:\SteamLibrary\steamapps\common\DB Xenoverse 2\cpk\data\data\system\char_advance_transform.cat.xml" };
             //args = new string[1] { @"E:\VS_Test\EMA" };
 
             DEBUG_MODE = true;
@@ -351,6 +351,9 @@ namespace XV2_Xml_Serializer
                                 case ".spm":
                                     Xv2CoreLib.SPM.SPM_File.SerializeToXml(fileLocation);
                                     break;
+                                case ".cat":
+                                    Xv2CoreLib.CAT.CAT_File.Parse(fileLocation, true);
+									break;
                                 case ".hkx":
                                 case ".hvk":
                                     Xv2CoreLib.Havok.HavokTagFile.SerializeToXml(fileLocation);
@@ -671,6 +674,9 @@ namespace XV2_Xml_Serializer
                         break;
                     case ".spm":
                         Xv2CoreLib.SPM.SPM_File.DeserializeFromXml(fileLocation);
+                        break;
+                    case ".cat":
+                        Xv2CoreLib.CAT.CAT_File.Write(fileLocation);
                         break;
                     case ".hkx":
                     case ".hvk":

--- a/Xv2CoreLib/Animation/EAN/EAN_File.cs
+++ b/Xv2CoreLib/Animation/EAN/EAN_File.cs
@@ -348,7 +348,7 @@ namespace Xv2CoreLib.EAN
             {
                 IsCamera = true,
                 I_08 = 37508,
-                Skeleton = skeleton.Copy()
+                Skeleton = skeleton.Clone()
             };
         }
 
@@ -402,7 +402,6 @@ namespace Xv2CoreLib.EAN
         }
 
         #endregion
-
     }
 
     [YAXSerializeAs("Animation")]

--- a/Xv2CoreLib/Animation/EAN/EAN_File.cs
+++ b/Xv2CoreLib/Animation/EAN/EAN_File.cs
@@ -348,7 +348,7 @@ namespace Xv2CoreLib.EAN
             {
                 IsCamera = true,
                 I_08 = 37508,
-                Skeleton = skeleton.Clone()
+                Skeleton = skeleton.Copy()
             };
         }
 
@@ -400,6 +400,7 @@ namespace Xv2CoreLib.EAN
         {
             return (Animations.Count == 0);
         }
+
 
         #endregion
     }

--- a/Xv2CoreLib/BEV/BEV_File.cs
+++ b/Xv2CoreLib/BEV/BEV_File.cs
@@ -97,6 +97,9 @@ namespace Xv2CoreLib.BEV
         [YAXDontSerializeIfNull]
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BEV_Type6")]
         public List<Type_6> Type6 { get; set; }
+        [YAXDontSerializeIfNull]
+        [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BEV_Type8")]
+        public List<Type_8> Type8 { get; set; }
     }
     
     //Data Types below
@@ -482,6 +485,76 @@ namespace Xv2CoreLib.BEV
         public int I_44 { get; set; }
     }
 
+    [YAXSerializeAs("BEV_Type8")]
+    public class Type_8 : TypeDef
+    {
+        [YAXAttributeForClass]
+        [YAXSerializeAs("StartTime")]
+        public ushort I_00 { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("Duration")]
+        public ushort I_02 { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("Layer")]
+        public int Idx { get; set; }
+        [YAXAttributeFor("I_04")]
+        [YAXSerializeAs("value")]
+        public uint I_04 { get; set; }
+        [YAXAttributeFor("I_08")]
+        [YAXSerializeAs("value")]
+        public uint I_08 { get; set; }
+        [YAXAttributeFor("I_12")]
+        [YAXSerializeAs("value")]
+        public uint I_12 { get; set; }
+        [YAXAttributeFor("I_16")]
+        [YAXSerializeAs("value")]
+        public uint I_16 { get; set; }
+        [YAXAttributeFor("I_20")]
+        [YAXSerializeAs("value")]
+        public uint I_20 { get; set; }
+        [YAXAttributeFor("I_24")]
+        [YAXSerializeAs("value")]
+        public uint I_24 { get; set; }
+        [YAXAttributeFor("I_28")]
+        [YAXSerializeAs("value")]
+        public uint I_28 { get; set; }
+        [YAXAttributeFor("I_32")]
+        [YAXSerializeAs("value")]
+        public uint I_32 { get; set; }
+        [YAXAttributeFor("I_36")]
+        [YAXSerializeAs("value")]
+        public uint I_36 { get; set; }
+        [YAXAttributeFor("I_40")]
+        [YAXSerializeAs("value")]
+        public uint I_40 { get; set; }
+        [YAXAttributeFor("I_44")]
+        [YAXSerializeAs("value")]
+        public uint I_44 { get; set; }
+        [YAXAttributeFor("I_48")]
+        [YAXSerializeAs("value")]
+        public uint I_48 { get; set; }
+        [YAXAttributeFor("I_52")]
+        [YAXSerializeAs("value")]
+        public uint I_52 { get; set; }
+        [YAXAttributeFor("I_56")]
+        [YAXSerializeAs("value")]
+        public uint I_56 { get; set; }
+        [YAXAttributeFor("I_60")]
+        [YAXSerializeAs("value")]
+        public uint I_60 { get; set; }
+        [YAXAttributeFor("I_64")]
+        [YAXSerializeAs("value")]
+        public uint I_64 { get; set; }
+        [YAXAttributeFor("I_68")]
+        [YAXSerializeAs("value")]
+        public uint I_68 { get; set; }
+        [YAXAttributeFor("I_72")]
+        [YAXSerializeAs("value")]
+        public uint I_72 { get; set; }
+        [YAXAttributeFor("I_76")]
+        [YAXSerializeAs("value")]
+        public uint I_76 { get; set; }
+    }
 
     public interface TypeDef
     {

--- a/Xv2CoreLib/BEV/BEV_File.cs
+++ b/Xv2CoreLib/BEV/BEV_File.cs
@@ -98,6 +98,9 @@ namespace Xv2CoreLib.BEV
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BEV_Type6")]
         public List<Type_6> Type6 { get; set; }
         [YAXDontSerializeIfNull]
+        [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BEV_Type7")]
+        public List<Type_7> Type7 { get; set; }
+        [YAXDontSerializeIfNull]
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BEV_Type8")]
         public List<Type_8> Type8 { get; set; }
     }
@@ -450,7 +453,7 @@ namespace Xv2CoreLib.BEV
         [YAXAttributeFor("F_08")]
         [YAXSerializeAs("value")]
         [YAXFormat("0.#########")]
-        public float F_08{ get; set; }
+        public float F_08 { get; set; }
         [YAXAttributeFor("F_12")]
         [YAXSerializeAs("value")]
         [YAXFormat("0.#########")]
@@ -483,6 +486,131 @@ namespace Xv2CoreLib.BEV
         [YAXAttributeFor("I_44")]
         [YAXSerializeAs("value")]
         public int I_44 { get; set; }
+    }
+
+    [YAXSerializeAs("BEV_Type7")]
+    public class Type_7 : TypeDef
+    {
+        [YAXAttributeForClass]
+        [YAXSerializeAs("StartTime")]
+        public ushort I_00 { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("Duration")]
+        public ushort I_02 { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("Layer")]
+        public int Idx { get; set; }
+        [YAXAttributeFor("I_04")]
+        [YAXSerializeAs("value")]
+        public int I_04 { get; set; }
+        [YAXAttributeFor("I_08")]
+        [YAXSerializeAs("value")]
+        public int I_08 { get; set; }
+        [YAXAttributeFor("I_12")]
+        [YAXSerializeAs("value")]
+        public int I_12 { get; set; }
+        [YAXAttributeFor("I_16")]
+        [YAXSerializeAs("value")]
+        public int I_16 { get; set; }
+        [YAXAttributeFor("F_20")]
+        [YAXSerializeAs("value")]
+        public float F_20 { get; set; }
+        [YAXAttributeFor("I_24")]
+        [YAXSerializeAs("value")]
+        public int I_24 { get; set; }
+        [YAXAttributeFor("I_28")]
+        [YAXSerializeAs("value")]
+        public int I_28 { get; set; }
+        [YAXAttributeFor("F_32")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_32 { get; set; }
+        [YAXAttributeFor("I_36")]
+        [YAXSerializeAs("value")]
+        public int I_36 { get; set; }
+        [YAXAttributeFor("I_40")]
+        [YAXSerializeAs("value")]
+        public int I_40 { get; set; }
+        [YAXAttributeFor("I_44")]
+        [YAXSerializeAs("value")]
+        public int I_44 { get; set; }
+        [YAXAttributeFor("F_48")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_48 { get; set; }
+        [YAXAttributeFor("I_52")]
+        [YAXSerializeAs("value")]
+        public int I_52 { get; set; }
+        [YAXAttributeFor("F_56")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_56 { get; set; }
+        [YAXAttributeFor("F_60")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_60 { get; set; }
+        [YAXAttributeFor("I_64")]
+        [YAXSerializeAs("value")]
+        public int I_64 { get; set; }
+        [YAXAttributeFor("I_68")]
+        [YAXSerializeAs("value")]
+        public int I_68 { get; set; }
+        [YAXAttributeFor("I_72")]
+        [YAXSerializeAs("value")]
+        public int I_72 { get; set; }
+        [YAXAttributeFor("F_76")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_76 { get; set; }
+        [YAXAttributeFor("F_80")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.#########")]
+        public float F_80 { get; set; }
+        [YAXAttributeFor("I_84")]
+        [YAXSerializeAs("value")]
+        public int I_84 { get; set; }
+        [YAXAttributeFor("I_88")]
+        [YAXSerializeAs("value")]
+        public int I_88 { get; set; }
+        [YAXAttributeFor("I_92")]
+        [YAXSerializeAs("value")]
+        public int I_92 { get; set; }
+        [YAXAttributeFor("I_96")]
+        [YAXSerializeAs("value")]
+        public int I_96 { get; set; }
+        [YAXAttributeFor("I_100")]
+        [YAXSerializeAs("value")]
+        public int I_100 { get; set; }
+        [YAXAttributeFor("I_104")]
+        [YAXSerializeAs("value")]
+        public int I_104 { get; set; }
+        [YAXAttributeFor("I_108")]
+        [YAXSerializeAs("value")]
+        public int I_108 { get; set; }
+        [YAXAttributeFor("I_112")]
+        [YAXSerializeAs("value")]
+        public int I_112 { get; set; }
+        [YAXAttributeFor("I_116")]
+        [YAXSerializeAs("value")]
+        public int I_116 { get; set; }
+        [YAXAttributeFor("I_120")]
+        [YAXSerializeAs("value")]
+        public int I_120 { get; set; }
+        [YAXAttributeFor("I_124")]
+        [YAXSerializeAs("value")]
+        public int I_124 { get; set; }
+        [YAXAttributeFor("I_128")]
+        [YAXSerializeAs("value")]
+        public int I_128 { get; set; }
+        [YAXAttributeFor("I_132")]
+        [YAXSerializeAs("value")]
+        public int I_132 { get; set; }
+        [YAXAttributeFor("I_136")]
+        [YAXSerializeAs("value")]
+        public int I_136 { get; set; }
+        [YAXAttributeFor("I_140")]
+        [YAXSerializeAs("value")]
+        public int I_140 { get; set; }
     }
 
     [YAXSerializeAs("BEV_Type8")]

--- a/Xv2CoreLib/BEV/Deserializer.cs
+++ b/Xv2CoreLib/BEV/Deserializer.cs
@@ -106,6 +106,9 @@ namespace Xv2CoreLib.BEV
                             case 6:
                                 typeCount = bevFile.Entries[i].Type6.Count(entry => entry.Idx == e._Idx);
                                 break;
+                            case 8:
+                                typeCount = bevFile.Entries[i].Type8.Count(entry => entry.Idx == e._Idx);
+                                break;
                         }
 
                         bytes.AddRange(BitConverter.GetBytes((short)e._Type));
@@ -176,7 +179,11 @@ namespace Xv2CoreLib.BEV
                                 break;
                             case 6:
                                 WriteType6(bevFile.Entries[i].Type6, e._Idx);
-                                SizeCheck(size, bytes.Count(), 48, 5, bevFile.Entries[i].Type6.Count(entry => entry.Idx == e._Idx));
+                                SizeCheck(size, bytes.Count(), 48, 6, bevFile.Entries[i].Type6.Count(entry => entry.Idx == e._Idx));
+                                break;
+                            case 8:
+                                WriteType8(bevFile.Entries[i].Type8, e._Idx);
+                                SizeCheck(size, bytes.Count(), 80, 8, bevFile.Entries[i].Type8.Count(entry => entry.Idx == e._Idx));
                                 break;
                         }
 
@@ -281,6 +288,17 @@ namespace Xv2CoreLib.BEV
                 });
             }
 
+            //Type8
+            List<int> _type8 = TotalCount(entry.Type8);
+            foreach (int e in _type8)
+            {
+                _types.Add(new TypeEntry()
+                {
+                    _Idx = e,
+                    _Type = 8
+                });
+            }
+
             return _types;
         }
 
@@ -295,6 +313,7 @@ namespace Xv2CoreLib.BEV
             count += TotalCount(entry.Type4).Count;
             count += TotalCount(entry.Type5).Count;
             count += TotalCount(entry.Type6).Count;
+            count += TotalCount(entry.Type8).Count;
 
             return count;
         }
@@ -396,6 +415,22 @@ namespace Xv2CoreLib.BEV
         }
 
         private List<int> TotalCount(List<Type_6> types)
+        {
+            List<int> count = new List<int>();
+            if (types != null)
+            {
+                for (int i = 0; i < types.Count; i++)
+                {
+                    if (count.IndexOf(types[i].Idx) == -1)
+                    {
+                        count.Add(types[i].Idx);
+                    }
+                }
+            }
+            return count;
+        }
+
+        private List<int> TotalCount(List<Type_8> types)
         {
             List<int> count = new List<int>();
             if (types != null)
@@ -601,6 +636,39 @@ namespace Xv2CoreLib.BEV
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_36));
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_40));
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_44));
+                }
+            }
+
+        }
+
+        void WriteType8(List<Type_8> type, int _idx)
+        {
+
+            for (int i = 0; i < type.Count(); i++)
+            {
+                if (type[i].Idx == _idx)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_00));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)(type[i].I_00 + type[i].I_02)));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_04));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_20));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_24));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_28));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_32));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_36));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_40));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_44));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_48));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_52));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_56));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_60));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_64));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_68));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_72));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_76));
                 }
             }
 

--- a/Xv2CoreLib/BEV/Deserializer.cs
+++ b/Xv2CoreLib/BEV/Deserializer.cs
@@ -106,6 +106,9 @@ namespace Xv2CoreLib.BEV
                             case 6:
                                 typeCount = bevFile.Entries[i].Type6.Count(entry => entry.Idx == e._Idx);
                                 break;
+                            case 7:
+                                typeCount = bevFile.Entries[i].Type7.Count(entry => entry.Idx == e._Idx);
+                                break;
                             case 8:
                                 typeCount = bevFile.Entries[i].Type8.Count(entry => entry.Idx == e._Idx);
                                 break;
@@ -180,6 +183,10 @@ namespace Xv2CoreLib.BEV
                             case 6:
                                 WriteType6(bevFile.Entries[i].Type6, e._Idx);
                                 SizeCheck(size, bytes.Count(), 48, 6, bevFile.Entries[i].Type6.Count(entry => entry.Idx == e._Idx));
+                                break;
+                            case 7:
+                                WriteType7(bevFile.Entries[i].Type7, e._Idx);
+                                SizeCheck(size, bytes.Count(), 144, 7, bevFile.Entries[i].Type7.Count(entry => entry.Idx == e._Idx));
                                 break;
                             case 8:
                                 WriteType8(bevFile.Entries[i].Type8, e._Idx);
@@ -288,6 +295,17 @@ namespace Xv2CoreLib.BEV
                 });
             }
 
+            //Type7
+            List<int> _type7 = TotalCount(entry.Type7);
+            foreach (int e in _type7)
+            {
+                _types.Add(new TypeEntry()
+                {
+                    _Idx = e,
+                    _Type = 7
+                });
+            }
+
             //Type8
             List<int> _type8 = TotalCount(entry.Type8);
             foreach (int e in _type8)
@@ -313,6 +331,7 @@ namespace Xv2CoreLib.BEV
             count += TotalCount(entry.Type4).Count;
             count += TotalCount(entry.Type5).Count;
             count += TotalCount(entry.Type6).Count;
+            count += TotalCount(entry.Type7).Count;
             count += TotalCount(entry.Type8).Count;
 
             return count;
@@ -415,6 +434,22 @@ namespace Xv2CoreLib.BEV
         }
 
         private List<int> TotalCount(List<Type_6> types)
+        {
+            List<int> count = new List<int>();
+            if (types != null)
+            {
+                for (int i = 0; i < types.Count; i++)
+                {
+                    if (count.IndexOf(types[i].Idx) == -1)
+                    {
+                        count.Add(types[i].Idx);
+                    }
+                }
+            }
+            return count;
+        }
+
+        private List<int> TotalCount(List<Type_7> types)
         {
             List<int> count = new List<int>();
             if (types != null)
@@ -636,6 +671,55 @@ namespace Xv2CoreLib.BEV
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_36));
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_40));
                     bytes.AddRange(BitConverter.GetBytes(type[i].I_44));
+                }
+            }
+
+        }
+
+        void WriteType7(List<Type_7> type, int _idx)
+        {
+
+            for (int i = 0; i < type.Count(); i++)
+            {
+                if (type[i].Idx == _idx)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_00));
+                    bytes.AddRange(BitConverter.GetBytes((ushort)(type[i].I_00 + type[i].I_02)));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_04));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_12));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_20));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_24));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_28));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_32));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_36));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_40));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_44));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_48));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_52));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_56));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_60));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_64));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_68));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_72));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_76));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_80));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_84));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_88));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_92));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_96));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_100));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_104));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_108));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_112));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_116));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_120));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_124));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_128));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_132));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_136));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_140));
                 }
             }
 

--- a/Xv2CoreLib/BEV/Parser.cs
+++ b/Xv2CoreLib/BEV/Parser.cs
@@ -59,6 +59,7 @@ namespace Xv2CoreLib.BEV
                 int type4 = 0;
                 int type5 = 0;
                 int type6 = 0;
+                int type8 = 0;
 
                 if (count > 0)
                 {
@@ -104,6 +105,10 @@ namespace Xv2CoreLib.BEV
                                 {
                                     goto default;
                                 }
+                                break;
+                            case 8:
+                                bevFile.Entries[i].Type8 = GetType8(typeCount, typeoffset, bevFile.Entries[i].Type8, type8);
+                                type6++;
                                 break;
                             default:
                                 Console.WriteLine(String.Format("Encountered undefined BEV_Type = {0} (offset = {1}). Unable to continue.", type, offset));
@@ -361,6 +366,48 @@ namespace Xv2CoreLib.BEV
                 });
 
                 offset += 48;
+
+            }
+
+            return _type;
+        }
+
+        List<Type_8> GetType8(short count, int offset, List<Type_8> _type, int idx)
+        {
+            if (_type == null)
+            {
+                _type = new List<Type_8>();
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                _type.Add(new Type_8()
+                {
+                    Idx = idx,
+                    I_00 = BitConverter.ToUInt16(rawBytes, offset + 0),
+                    I_02 = (ushort)(BitConverter.ToUInt16(rawBytes, offset + 2) - BitConverter.ToUInt16(rawBytes, offset + 0)),
+                    I_04 = BitConverter.ToUInt32(rawBytes, offset + 4),
+                    I_08 = BitConverter.ToUInt32(rawBytes, offset + 8),
+                    I_12 = BitConverter.ToUInt32(rawBytes, offset + 12),
+                    I_16 = BitConverter.ToUInt32(rawBytes, offset + 16),
+                    I_20 = BitConverter.ToUInt32(rawBytes, offset + 20),
+                    I_24 = BitConverter.ToUInt32(rawBytes, offset + 24),
+                    I_28 = BitConverter.ToUInt32(rawBytes, offset + 28),
+                    I_32 = BitConverter.ToUInt32(rawBytes, offset + 32),
+                    I_36 = BitConverter.ToUInt32(rawBytes, offset + 36),
+                    I_40 = BitConverter.ToUInt32(rawBytes, offset + 40),
+                    I_44 = BitConverter.ToUInt32(rawBytes, offset + 44),
+                    I_48 = BitConverter.ToUInt32(rawBytes, offset + 48),
+                    I_52 = BitConverter.ToUInt32(rawBytes, offset + 52),
+                    I_56 = BitConverter.ToUInt32(rawBytes, offset + 56),
+                    I_60 = BitConverter.ToUInt32(rawBytes, offset + 60),
+                    I_64 = BitConverter.ToUInt32(rawBytes, offset + 64),
+                    I_68 = BitConverter.ToUInt32(rawBytes, offset + 68),
+                    I_72 = BitConverter.ToUInt32(rawBytes, offset + 72),
+                    I_76 = BitConverter.ToUInt32(rawBytes, offset + 76),
+                });
+
+                offset += 80;
 
             }
 

--- a/Xv2CoreLib/BEV/Parser.cs
+++ b/Xv2CoreLib/BEV/Parser.cs
@@ -108,7 +108,7 @@ namespace Xv2CoreLib.BEV
                                 break;
                             case 8:
                                 bevFile.Entries[i].Type8 = GetType8(typeCount, typeoffset, bevFile.Entries[i].Type8, type8);
-                                type6++;
+                                type8++;
                                 break;
                             default:
                                 Console.WriteLine(String.Format("Encountered undefined BEV_Type = {0} (offset = {1}). Unable to continue.", type, offset));

--- a/Xv2CoreLib/BEV/Parser.cs
+++ b/Xv2CoreLib/BEV/Parser.cs
@@ -59,6 +59,7 @@ namespace Xv2CoreLib.BEV
                 int type4 = 0;
                 int type5 = 0;
                 int type6 = 0;
+                int type7 = 0;
                 int type8 = 0;
 
                 if (count > 0)
@@ -101,10 +102,14 @@ namespace Xv2CoreLib.BEV
                                 type6++;
                                 break;
                             case 7:
-                                if(typeCount != 0 || typeoffset != 0)
+                                if (typeCount == 0 || typeoffset == 0)
                                 {
-                                    goto default;
+                                    // In common.bev there's still a reference to a type7 with count as 0
+                                    break;
                                 }
+                                Console.WriteLine(String.Format("Encountered undefined BEV_Type = {0} (offset = {1}). Unable to continue.", type, offset));
+                                bevFile.Entries[i].Type7 = GetType7(typeCount, typeoffset, bevFile.Entries[i].Type7, type7);
+                                type7++;
                                 break;
                             case 8:
                                 bevFile.Entries[i].Type8 = GetType8(typeCount, typeoffset, bevFile.Entries[i].Type8, type8);
@@ -366,6 +371,63 @@ namespace Xv2CoreLib.BEV
                 });
 
                 offset += 48;
+
+            }
+
+            return _type;
+        }
+
+        List<Type_7> GetType7(short count, int offset, List<Type_7> _type, int idx)
+        {
+            if (_type == null)
+            {
+                _type = new List<Type_7>();
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                _type.Add(new Type_7()
+                {
+                    Idx = idx,
+                    I_00 = BitConverter.ToUInt16(rawBytes, offset + 0),
+                    I_02 = (ushort)(BitConverter.ToUInt16(rawBytes, offset + 2) - BitConverter.ToUInt16(rawBytes, offset + 0)),
+                    I_04 = BitConverter.ToInt32(rawBytes, offset + 4),
+                    I_08 = BitConverter.ToInt32(rawBytes, offset + 8),
+                    I_12 = BitConverter.ToInt32(rawBytes, offset + 12),
+                    I_16 = BitConverter.ToInt32(rawBytes, offset + 16),
+                    F_20 = BitConverter.ToSingle(rawBytes, offset + 20),
+                    I_24 = BitConverter.ToInt32(rawBytes, offset + 24),
+                    I_28 = BitConverter.ToInt32(rawBytes, offset + 28),
+                    F_32 = BitConverter.ToSingle(rawBytes, offset + 32),
+                    I_36 = BitConverter.ToInt32(rawBytes, offset + 36),
+                    I_40 = BitConverter.ToInt32(rawBytes, offset + 40),
+                    F_48 = BitConverter.ToSingle(rawBytes, offset + 48),
+                    I_52 = BitConverter.ToInt32(rawBytes, offset + 52),
+                    F_56 = BitConverter.ToSingle(rawBytes, offset + 56),
+                    F_60 = BitConverter.ToSingle(rawBytes, offset + 60),
+                    I_64 = BitConverter.ToInt32(rawBytes, offset + 64),
+                    I_68 = BitConverter.ToInt32(rawBytes, offset + 68),
+                    I_72 = BitConverter.ToInt32(rawBytes, offset + 72),
+                    F_76 = BitConverter.ToSingle(rawBytes, offset + 76),
+                    F_80 = BitConverter.ToSingle(rawBytes, offset + 80),
+                    I_84 = BitConverter.ToInt32(rawBytes, offset + 84),
+                    I_88 = BitConverter.ToInt32(rawBytes, offset + 88),
+                    I_92 = BitConverter.ToInt32(rawBytes, offset + 92),
+                    I_96 = BitConverter.ToInt32(rawBytes, offset + 96),
+                    I_100 = BitConverter.ToInt32(rawBytes, offset + 100),
+                    I_104 = BitConverter.ToInt32(rawBytes, offset + 104),
+                    I_108 = BitConverter.ToInt32(rawBytes, offset + 108),
+                    I_112 = BitConverter.ToInt32(rawBytes, offset + 112),
+                    I_116 = BitConverter.ToInt32(rawBytes, offset + 116),
+                    I_120 = BitConverter.ToInt32(rawBytes, offset + 120),
+                    I_124 = BitConverter.ToInt32(rawBytes, offset + 124),
+                    I_128 = BitConverter.ToInt32(rawBytes, offset + 128),
+                    I_132 = BitConverter.ToInt32(rawBytes, offset + 132),
+                    I_136 = BitConverter.ToInt32(rawBytes, offset + 136),
+                    I_140 = BitConverter.ToInt32(rawBytes, offset + 140),
+                });
+
+                offset += 144;
 
             }
 

--- a/Xv2CoreLib/BSA/BSA_File.cs
+++ b/Xv2CoreLib/BSA/BSA_File.cs
@@ -275,6 +275,11 @@ namespace Xv2CoreLib.BSA
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BSA_Type13")]
         [BindingSubList]
         public List<BSA_Type13> Type13 { get; set; }
+
+        [YAXDontSerializeIfNull]
+        [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BSA_Type14")]
+        [BindingSubList]
+        public List<BSA_Type14> Type14 { get; set; }
         #region IBsaTypes
         [YAXDontSerialize]
         public AsyncObservableCollection<IBsaType> IBsaTypes { get; set; }
@@ -304,6 +309,8 @@ namespace Xv2CoreLib.BSA
             foreach (var bsaEntry in Type12)
                 IBsaTypes.Add(bsaEntry);
             foreach (var bsaEntry in Type13)
+                IBsaTypes.Add(bsaEntry);
+            foreach (var bsaEntry in Type14)
                 IBsaTypes.Add(bsaEntry);
 
         }
@@ -354,6 +361,10 @@ namespace Xv2CoreLib.BSA
                 {
                     Type13.Add(type13);
                 }
+                else if (bsaEntry is BSA_Type14 type14)
+                {
+                    Type14.Add(type14);
+                }
             }
         }
 
@@ -379,6 +390,8 @@ namespace Xv2CoreLib.BSA
                 Type12 = new List<BSA_Type12>();
             if (Type13 == null)
                 Type13 = new List<BSA_Type13>();
+            if (Type14 == null)
+                Type14 = new List<BSA_Type14>();
         }
 
         private void ClearBsaLists()
@@ -395,6 +408,7 @@ namespace Xv2CoreLib.BSA
             Type8.Clear();
             Type12.Clear();
             Type13.Clear();
+            Type14.Clear();
         }
 
         #endregion
@@ -997,6 +1011,93 @@ namespace Xv2CoreLib.BSA
         public int I_28 { get; set; }
 
 
+    }
+
+    [YAXSerializeAs("BSA_Type14")]
+    [Serializable]
+    public class BSA_Type14 : IBsaType
+    {
+        [YAXAttributeFor("Start_Time")]
+        [YAXSerializeAs("frames")]
+        public ushort StartTime { get; set; }
+        [YAXAttributeFor("Duration")]
+        [YAXSerializeAs("frames")]
+        public ushort Duration { get; set; }
+        [YAXAttributeFor("I_00")]
+        [YAXSerializeAs("value")]
+        public ushort I_00 { get; set; }
+        [YAXAttributeFor("I_02")]
+        [YAXSerializeAs("value")]
+        public ushort I_02 { get; set; }
+        [YAXAttributeFor("F_04")]
+        [YAXSerializeAs("value")]
+        public float F_04 { get; set; } // For some reason if we add YAXFormat to this, it always formats to 0
+        [YAXAttributeFor("I_08")]
+        [YAXSerializeAs("value")]
+        public uint I_08 { get; set; }
+        [YAXAttributeFor("F_12")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_12 { get; set; }
+        [YAXAttributeFor("I_16")]
+        [YAXSerializeAs("value")]
+        public uint I_16 { get; set; }
+        [YAXAttributeFor("F_20")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_20 { get; set; }
+        [YAXAttributeFor("I_24")]
+        [YAXSerializeAs("value")]
+        public uint I_24 { get; set; }
+        [YAXAttributeFor("F_28")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_28 { get; set; }
+        [YAXAttributeFor("I_32")]
+        [YAXSerializeAs("value")]
+        public uint I_32 { get; set; }
+        [YAXAttributeFor("I_36")]
+        [YAXSerializeAs("value")]
+        public uint I_36 { get; set; }
+        [YAXAttributeFor("I_40")]
+        [YAXSerializeAs("value")]
+        public uint I_40 { get; set; }
+        [YAXAttributeFor("F_44")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_44 { get; set; }
+        [YAXAttributeFor("I_48")]
+        [YAXSerializeAs("value")]
+        public uint I_48 { get; set; }
+        [YAXAttributeFor("F_52")]
+        [YAXSerializeAs("value")]
+        public float F_52 { get; set; }
+        [YAXAttributeFor("I_56")]
+        [YAXSerializeAs("value")]
+        public uint I_56 { get; set; }
+        [YAXAttributeFor("F_60")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_60 { get; set; }
+        [YAXAttributeFor("I_64")]
+        [YAXSerializeAs("value")]
+        public uint I_64 { get; set; }
+        [YAXAttributeFor("F_68")]
+        [YAXSerializeAs("value")]
+        [YAXFormat("0.0##########")]
+        public float F_68 { get; set; }
+        [YAXAttributeFor("I_72")]
+        [YAXSerializeAs("value")]
+        public uint I_72 { get; set; }
+        [YAXAttributeFor("I_76")]
+        [YAXSerializeAs("value")]
+        public uint I_76 { get; set; }
+        [YAXAttributeFor("I_80")]
+        [YAXSerializeAs("value")]
+        public uint I_80 { get; set; }
+        [YAXAttributeFor("I_84")]
+        [YAXSerializeAs("value")]
+        public uint I_84 { get; set; }
     }
 
     public interface IBsaType

--- a/Xv2CoreLib/BSA/Deserializer.cs
+++ b/Xv2CoreLib/BSA/Deserializer.cs
@@ -252,6 +252,13 @@ namespace Xv2CoreLib.BSA
                     dataOffset.Add(results[1]);
                     typeList.Add(13);
                 }
+                if (types.Type14 != null)
+                {
+                    var results = WriteTypeHeader(14, types.Type14.Count);
+                    hdrOffset.Add(results[0]);
+                    dataOffset.Add(results[1]);
+                    typeList.Add(14);
+                }
 
                 //Type Data
                 for (int i = 0; i < typeList.Count; i++)
@@ -290,6 +297,9 @@ namespace Xv2CoreLib.BSA
                             break;
                         case 13:
                             WriteType13(types.Type13, hdrOffset[i], dataOffset[i]);
+                            break;
+                        case 14:
+                            WriteType14(types.Type14, hdrOffset[i], dataOffset[i]);
                             break;
                     }
 
@@ -690,7 +700,53 @@ namespace Xv2CoreLib.BSA
             }
 
         }
+        private void WriteType14(List<BSA_Type14> type, int hdrOffset, int dataOffset)
+        {
+            if (type != null)
+            {
 
+                //Hdr data
+                bytes = Utils.ReplaceRange(bytes, BitConverter.GetBytes(bytes.Count - hdrOffset + 8), hdrOffset);
+
+                for (int i = 0; i < type.Count; i++)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(type[i].StartTime));
+                    bytes.AddRange(BitConverter.GetBytes(GetTypeEndTime(type[i].StartTime, type[i].Duration)));
+                }
+
+                //Main Type Data
+                bytes = Utils.ReplaceRange(bytes, BitConverter.GetBytes(bytes.Count - dataOffset + 12), dataOffset);
+
+                for (int i = 0; i < type.Count; i++)
+                {
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_00));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_02));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_04));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_08));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_12));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_16));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_20));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_24));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_28));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_32));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_36));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_40));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_44));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_48));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_52));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_56));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_60));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_64));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].F_68));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_72));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_76));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_80));
+                    bytes.AddRange(BitConverter.GetBytes(type[i].I_84));
+                }
+
+            }
+
+        }
 
         //Utility 
         private int BsaTypeCount(BSA_Entry bsaEntry)
@@ -737,6 +793,10 @@ namespace Xv2CoreLib.BSA
                 count++;
             }
             if (bsaEntry.Type13 != null)
+            {
+                count++;
+            }
+            if (bsaEntry.Type14 != null)
             {
                 count++;
             }

--- a/Xv2CoreLib/BSA/Parser.cs
+++ b/Xv2CoreLib/BSA/Parser.cs
@@ -136,6 +136,9 @@ namespace Xv2CoreLib.BSA
                                 case 13:
                                     bsaFile.BSA_Entries[thisEntry].Type13 = ParseType13(hdrOffset, dataOffset, typeCount);
                                     break;
+                                case 14:
+                                    bsaFile.BSA_Entries[thisEntry].Type14 = ParseType14(hdrOffset, dataOffset, typeCount);
+                                    break;
                                 default:
                                     //Attempt to estimate the unknown type size
                                     int estSize = (a + 1 < typesCount) ? BitConverter.ToInt16(rawBytes, typesOffset + 6 + 16) : -1;
@@ -147,7 +150,6 @@ namespace Xv2CoreLib.BSA
                                     }
 
                                     Console.WriteLine(String.Format("Undefined BSA Type encountered: {0}, at: def offset: {1}, data offset: {2}, count: {3}, estTypeSize: {4}", type, typesOffset, dataOffset, typeCount, estSize));
-                                    Console.ReadLine();
                                     break;
                             }
 
@@ -596,6 +598,55 @@ namespace Xv2CoreLib.BSA
                     });
                     hdrOffset += 4;
                     offset += 32;
+                }
+
+                return Type;
+
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private List<BSA_Type14> ParseType14(int hdrOffset, int offset, int count)
+        {
+            if (count > 0)
+            {
+                List<BSA_Type14> Type = new List<BSA_Type14>();
+
+                for (int i = 0; i < count; i++)
+                {
+                    Type.Add(new BSA_Type14()
+                    {
+                        I_00 = BitConverter.ToUInt16(rawBytes, offset + 0),
+                        I_02 = BitConverter.ToUInt16(rawBytes, offset + 2),
+                        F_04 = BitConverter.ToSingle(rawBytes, offset + 4),
+                        I_08 = BitConverter.ToUInt32(rawBytes, offset + 8),
+                        F_12 = BitConverter.ToSingle(rawBytes, offset + 12),
+                        I_16 = BitConverter.ToUInt32(rawBytes, offset + 16),
+                        F_20 = BitConverter.ToSingle(rawBytes, offset + 20),
+                        I_24 = BitConverter.ToUInt32(rawBytes, offset + 24),
+                        F_28 = BitConverter.ToSingle(rawBytes, offset + 28),
+                        I_32 = BitConverter.ToUInt32(rawBytes, offset + 32),
+                        I_36 = BitConverter.ToUInt32(rawBytes, offset + 36),
+                        I_40 = BitConverter.ToUInt32(rawBytes, offset + 40),
+                        F_44 = BitConverter.ToSingle(rawBytes, offset + 44),
+                        I_48 = BitConverter.ToUInt32(rawBytes, offset + 48),
+                        F_52 = BitConverter.ToSingle(rawBytes, offset + 52),
+                        I_56 = BitConverter.ToUInt32(rawBytes, offset + 56),
+                        F_60 = BitConverter.ToSingle(rawBytes, offset + 60),
+                        I_64 = BitConverter.ToUInt32(rawBytes, offset + 64),
+                        F_68 = BitConverter.ToSingle(rawBytes, offset + 68),
+                        I_72 = BitConverter.ToUInt32(rawBytes, offset + 72),
+                        I_76 = BitConverter.ToUInt32(rawBytes, offset + 76),
+                        I_80 = BitConverter.ToUInt32(rawBytes, offset + 80),
+                        I_84 = BitConverter.ToUInt32(rawBytes, offset + 84),
+                        StartTime = BitConverter.ToUInt16(rawBytes, hdrOffset + 0),
+                        Duration = GetTypeDuration(BitConverter.ToUInt16(rawBytes, hdrOffset + 0), BitConverter.ToUInt16(rawBytes, hdrOffset + 2)),
+                    });
+                    hdrOffset += 4;
+                    offset += 88;
                 }
 
                 return Type;

--- a/Xv2CoreLib/CAT/CAT_File.cs
+++ b/Xv2CoreLib/CAT/CAT_File.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace Xv2CoreLib.CAT
+{
+    [YAXSerializeAs("CAT")]
+    public class CAT_File
+    {
+        private const uint CAT_SIGNATURE = 0x54414323;
+        private const uint CAT_HEADER_SIZE = 0xC;
+
+        public const int CAT_ENTRY_SIZE = 0x18; // Ver 1 (original)
+
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 1)]
+        public int Version { get; set; }
+
+        [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "CATEntry")]
+        public List<CAT_Entry> Entries { get; set; } = new List<CAT_Entry>();
+
+        #region LoadSave
+        public static CAT_File Parse(string path, bool writeXml)
+        {
+            CAT_File file = Parse(File.ReadAllBytes(path));
+
+            if (writeXml)
+            {
+                YAXSerializer serializer = new YAXSerializer(typeof(CAT_File));
+                serializer.SerializeToFile(file, path + ".xml");
+            }
+
+            return file;
+        }
+
+        public static CAT_File Parse(byte[] bytes)
+        {
+            CAT_File CATFile = new CAT_File();
+            int numEntries = BitConverter.ToInt16(bytes, 6);
+            int entrySize = (int)((bytes.Length - CAT_HEADER_SIZE) / numEntries);
+            CATFile.Version = EntrySizeToVersion(entrySize);
+            int offset = BitConverter.ToInt16(bytes, 8);
+
+            if (bytes.Length != offset + (entrySize * numEntries))
+                throw new InvalidDataException($"Error on reading CAT file: Invalid file size!");
+
+            for(int i = 0; i < numEntries; i++)
+            {
+                CAT_Entry entry = new CAT_Entry();
+
+                entry.CharaId = BitConverter.ToUInt16(bytes, offset + 0);
+                entry.Costume = BitConverter.ToUInt16(bytes, offset + 2);
+                entry.I_04 = BitConverter.ToUInt16(bytes, offset + 4);
+                entry.I_06 = BitConverter.ToUInt16(bytes, offset + 6);
+                entry.Str_08 = StringEx.GetString(bytes, offset + 8, false, StringEx.EncodingType.ASCII, 8);
+                entry.I_12 = BitConverter.ToInt32(bytes, offset + 12);
+                entry.I_16 = BitConverter.ToInt32(bytes, offset + 16);
+                entry.I_20 = BitConverter.ToInt32(bytes, offset + 20);
+
+                offset += entrySize;
+                CATFile.Entries.Add(entry);
+            }
+
+            return CATFile;
+        }
+
+        /// <summary>
+        /// Parse the xml at the specified path and convert it into a binary .CAT file, and save it at the same path minus the .xml.
+        /// </summary>
+        public static void Write(string xmlPath)
+        {
+            string saveLocation = String.Format("{0}/{1}", Path.GetDirectoryName(xmlPath), Path.GetFileNameWithoutExtension(xmlPath));
+            YAXSerializer serializer = new YAXSerializer(typeof(CAT_File), YAXSerializationOptions.DontSerializeNullObjects);
+            var CATFile = (CAT_File)serializer.DeserializeFromFile(xmlPath);
+
+            File.WriteAllBytes(saveLocation, CATFile.Write());
+        }
+
+        /// <summary>
+        /// Save the CAT_File to the specified path.
+        /// </summary>
+        /// <param name="path"></param>
+        public void Save(string path)
+        {
+            File.WriteAllBytes(path, Write());
+        }
+
+        public byte[] Write()
+        {
+            if (Entries == null) Entries = new List<CAT_Entry>();
+
+            List<byte> bytes = new List<byte>();
+
+            uint offset = (int)CAT_HEADER_SIZE;
+
+            //Header
+            bytes.AddRange(BitConverter.GetBytes(CAT_SIGNATURE));
+            bytes.AddRange(BitConverter.GetBytes((ushort)65534));
+            bytes.AddRange(BitConverter.GetBytes((ushort)Entries.Count));
+            bytes.AddRange(BitConverter.GetBytes(offset));
+
+            //Entries
+            foreach (var entry in Entries)
+            {
+                if (entry.Str_08.Length > 3)
+                    throw new Exception($"ShortName \"{entry.Str_08}\" exceeds 3 characters!");
+
+                bytes.AddRange(BitConverter.GetBytes(entry.CharaId));
+                bytes.AddRange(BitConverter.GetBytes(entry.Costume));
+                bytes.AddRange(BitConverter.GetBytes(entry.I_04));
+                bytes.AddRange(BitConverter.GetBytes(entry.I_06));
+                bytes.AddRange(Encoding.ASCII.GetBytes(entry.Str_08));
+                bytes.AddRange(new byte[4 - entry.Str_08.Length]);
+                bytes.AddRange(BitConverter.GetBytes(entry.I_12));
+                bytes.AddRange(BitConverter.GetBytes(entry.I_16));
+                bytes.AddRange(BitConverter.GetBytes(entry.I_20));
+            }
+
+            //validation
+            if (bytes.Count != CAT_HEADER_SIZE + ((int)CAT_ENTRY_SIZE * Entries.Count))
+                throw new InvalidDataException($"Error on building CAT: Invalid file size!");
+
+            return bytes.ToArray();
+        }
+
+        public byte[] SaveToBytes()
+        {
+            return Write();
+        }
+
+        public static int VersionToEntrySize(int version)
+        {
+            switch (version)
+            {
+                case 1:
+                    return CAT_ENTRY_SIZE;
+                default:
+                    throw new InvalidDataException($"CAT: This CAT version is not supported (Version: {version}).");
+            }
+        }
+
+        public static int EntrySizeToVersion(int entrySize)
+        {
+            // Add more for when file ever updates
+            switch (entrySize)
+            {
+                case CAT_ENTRY_SIZE:
+                    return 1;
+                default:
+                    throw new InvalidDataException($"CAT: This CAT version is not supported (EntrySize: {entrySize}).");
+            }
+        }
+        #endregion
+    }
+
+    [YAXSerializeAs("CATEntry")]
+    public class CAT_Entry : IInstallable
+    {
+        #region NonSerialized
+
+        //interface
+        [YAXDontSerialize]
+        public int SortID { get { return CharaId; } }
+        [YAXDontSerialize]
+        public string Index 
+        { 
+            get
+            { 
+                return $"{CharaId}_{Costume}";
+            }
+            set
+            {
+                string[] split = value.Split('_');
+
+                if (split.Length == 2)
+                {
+                    CharaId = ushort.Parse(split[0]);
+                    Costume = ushort.Parse(split[1]);
+                }
+            }
+        }
+        #endregion
+
+        [YAXAttributeForClass]
+        [YAXSerializeAs("CharaId")]
+        public ushort CharaId { get; set; }
+        [YAXAttributeForClass]
+        [YAXSerializeAs("Costume")]
+        public ushort Costume { get; set; }
+        [YAXAttributeFor("I_04")]
+        [YAXSerializeAs("value")]
+        public ushort I_04 { get; set; }
+        [YAXAttributeFor("Awoken_Skill_ID2")]
+        [YAXSerializeAs("value")]
+        public ushort I_06 { get; set; }
+        [YAXAttributeFor("Chara")]
+        [YAXSerializeAs("value")]
+        public string Str_08 { get; set; }
+        [YAXAttributeFor("I_12")]
+        [YAXSerializeAs("value")]
+        public int I_12 { get; set; }
+        [YAXAttributeFor("I_16")]
+        [YAXSerializeAs("value")]
+        public int I_16 { get; set; }
+        [YAXAttributeFor("I_20")]
+        [YAXSerializeAs("value")]
+        public int I_20 { get; set; }
+    }
+}

--- a/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
+++ b/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
@@ -605,7 +605,7 @@ namespace Xv2CoreLib
 
                 //Create default EAN if none was loaded (duplicate chara-unique one)
                 if (!moveFiles.EanFile.Any(x => x.IsDefault) && loadSkillFiles)
-                    moveFiles.AddEanFile(moveFiles.EanFile[0].File.Copy(), null, name);
+                    moveFiles.AddEanFile(moveFiles.EanFile[0].File.Clone(), null, name);
             }
 
             //CAM
@@ -628,7 +628,7 @@ namespace Xv2CoreLib
 
                 //Create default CAM.EAN if none was loaded (duplicate chara-unique one)
                 if (!moveFiles.CamEanFile.Any(x => x.IsDefault) && loadSkillFiles)
-                    moveFiles.AddCamEanFile(moveFiles.CamEanFile[0].File.Copy(), null, name);
+                    moveFiles.AddCamEanFile(moveFiles.CamEanFile[0].File.Clone(), null, name);
             }
 
             //AFTER BAC
@@ -1203,9 +1203,9 @@ namespace Xv2CoreLib
             //Load fce ean
             if (!string.IsNullOrWhiteSpace(cmsEntry.FceEanPath))
             {
-            string fceEanPath = Utils.ResolveRelativePath(string.Format("chara/{0}/{1}.fce.ean", cmsEntry.ShortName, cmsEntry.FceEanPath));
-            moveFiles.EanPaths.Add(fceEanPath);
-            moveFiles.EanFile.Add(new Xv2File<EAN_File>((EAN_File)FileManager.Instance.GetParsedFileFromGame(fceEanPath), fileIO.PathInGameDir(fceEanPath), !cmsEntry.IsSelfReference(cmsEntry.FceEanPath), null, false, MoveFileTypes.FCE_EAN, 0, true, MoveType.Character));
+                string fceEanPath = Utils.ResolveRelativePath(string.Format("chara/{0}/{1}.fce.ean", cmsEntry.ShortName, cmsEntry.FceEanPath));
+                moveFiles.EanPaths.Add(fceEanPath);
+                moveFiles.EanFile.Add(new Xv2File<EAN_File>((EAN_File)FileManager.Instance.GetParsedFileFromGame(fceEanPath), fileIO.PathInGameDir(fceEanPath), !cmsEntry.IsSelfReference(cmsEntry.FceEanPath), null, false, MoveFileTypes.FCE_EAN, 0, true, MoveType.Character));
             }
 
             //fce.ean for foreheads

--- a/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
+++ b/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
@@ -1201,9 +1201,12 @@ namespace Xv2CoreLib
             }
 
             //Load fce ean
+            if (!string.IsNullOrWhiteSpace(cmsEntry.FceEanPath))
+            {
             string fceEanPath = Utils.ResolveRelativePath(string.Format("chara/{0}/{1}.fce.ean", cmsEntry.ShortName, cmsEntry.FceEanPath));
             moveFiles.EanPaths.Add(fceEanPath);
             moveFiles.EanFile.Add(new Xv2File<EAN_File>((EAN_File)FileManager.Instance.GetParsedFileFromGame(fceEanPath), fileIO.PathInGameDir(fceEanPath), !cmsEntry.IsSelfReference(cmsEntry.FceEanPath), null, false, MoveFileTypes.FCE_EAN, 0, true, MoveType.Character));
+            }
 
             //fce.ean for foreheads
             if (!string.IsNullOrWhiteSpace(cmsEntry.FceForeheadEanPath))

--- a/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
+++ b/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
@@ -605,7 +605,7 @@ namespace Xv2CoreLib
 
                 //Create default EAN if none was loaded (duplicate chara-unique one)
                 if (!moveFiles.EanFile.Any(x => x.IsDefault) && loadSkillFiles)
-                    moveFiles.AddEanFile(moveFiles.EanFile[0].File.Clone(), null, name);
+                    moveFiles.AddEanFile(moveFiles.EanFile[0].File.Copy(), null, name);
             }
 
             //CAM
@@ -628,7 +628,7 @@ namespace Xv2CoreLib
 
                 //Create default CAM.EAN if none was loaded (duplicate chara-unique one)
                 if (!moveFiles.CamEanFile.Any(x => x.IsDefault) && loadSkillFiles)
-                    moveFiles.AddCamEanFile(moveFiles.CamEanFile[0].File.Clone(), null, name);
+                    moveFiles.AddCamEanFile(moveFiles.CamEanFile[0].File.Copy(), null, name);
             }
 
             //AFTER BAC
@@ -1207,6 +1207,7 @@ namespace Xv2CoreLib
                 moveFiles.EanPaths.Add(fceEanPath);
                 moveFiles.EanFile.Add(new Xv2File<EAN_File>((EAN_File)FileManager.Instance.GetParsedFileFromGame(fceEanPath), fileIO.PathInGameDir(fceEanPath), !cmsEntry.IsSelfReference(cmsEntry.FceEanPath), null, false, MoveFileTypes.FCE_EAN, 0, true, MoveType.Character));
             }
+
 
             //fce.ean for foreheads
             if (!string.IsNullOrWhiteSpace(cmsEntry.FceForeheadEanPath))

--- a/Xv2CoreLib/Xv2CoreLib.csproj
+++ b/Xv2CoreLib/Xv2CoreLib.csproj
@@ -182,6 +182,7 @@
     <Compile Include="BSA_XV1\Deserializer.cs" />
     <Compile Include="BSA_XV1\Parser.cs" />
     <Compile Include="Animation\AnimationFramework\Interfaces.cs" />
+    <Compile Include="CAT\CAT_File.cs" />
     <Compile Include="EMD\ModelModifiedEvent.cs" />
     <Compile Include="FMP\CollisionCreator.cs" />
     <Compile Include="FMP\FMP_File.cs" />


### PR DESCRIPTION
Updates for files updated in v1.25;

BEV_Type8 was added and BEV_Type7 finally was used so we dont need to skip it anymore...

BSA Type 14 is an interesting one, I know that `I_56` is effect id, but it seems to always load from BTL_CMN2(?) I haven't done much testing with that, so I'll leave that to other people.

CAT file is something that people might want support for in the installer so I might see if I can implement that as well.

The check for `IsNullOrWhiteSpace` on the fce.ean is because `XAF` (new Shenron) has a CMS entry without a fce.ean value

The "fix" for Matrix4x4 might not be exactly what you had in mind, but it seems to work without any problems