### PR TITLE
update: BAS file parser for new version and implement version check

### DIFF
--- a/Xv2CoreLib/BAS/BAS_File.cs
+++ b/Xv2CoreLib/BAS/BAS_File.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +11,15 @@ namespace Xv2CoreLib.BAS
     [YAXSerializeAs("BAS")]
     public class BAS_File : IIsNull
     {
+        internal const byte CURRENT_VERSION = 2;
+        [YAXAttributeForClass]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = (byte)0)]
+        public byte Version { get; set; } = CURRENT_VERSION;
+
+        public const int ENTRY_SIZE_OLD = 84;
+        public const int ENTRY_SIZE_V1 = 88; //When they updated the AI for Crossversus
+        public const int ENTRY_SIZE_V2 = 92; //New in v1.24/1.25(?)
+
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "BAS_Entry")]
         public List<BAS_Entry> Entries { get; set; } = new List<BAS_Entry>();
 
@@ -34,10 +44,58 @@ namespace Xv2CoreLib.BAS
             new Deserializer(this, path);
         }
 
+        #region Helper
         public bool IsNull()
         {
             return Entries.Count == 0;
         }
+
+        public bool IsVersionValid()
+        {
+            return Version >= 0 && Version <= CURRENT_VERSION;
+        }
+
+        public static byte GetBasVersion(int size, int entryCount)
+        {
+            if (entryCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(entryCount));
+
+            int entrySize = (size - 28) / entryCount;
+
+            switch (entrySize)
+            {
+                case ENTRY_SIZE_OLD:
+                    return 0;
+
+                case ENTRY_SIZE_V1:
+                    return 1;
+
+                case ENTRY_SIZE_V2:
+                    return 2;
+
+                default:
+                    throw new InvalidDataException("BAS file version not supported.");
+            }
+        }
+
+        public static int GetSubEntrySize(int version)
+        {
+            switch (version)
+            {
+                case 0:
+                    return ENTRY_SIZE_OLD;
+
+                case 1:
+                    return ENTRY_SIZE_V1;
+
+                case 2:
+                    return ENTRY_SIZE_V2;
+
+                default:
+                    throw new InvalidDataException("BAS file version not supported.");
+            }
+        }
+        #endregion
     }
 
     public class BAS_Entry
@@ -116,6 +174,14 @@ namespace Xv2CoreLib.BAS
         [YAXSerializeAs("value")]
         [YAXFormat("0.0#########")]
         public float F_80 { get; set; }
+        [YAXAttributeFor("I_84")]
+        [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 0)]
+        public int I_84 { get; set; }
+        [YAXAttributeFor("I_88")]
+        [YAXSerializeAs("value")]
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore, DefaultValue = 0)]
+        public int I_88 { get; set; }
 
         public enum ActivationConditionTarget
         {

--- a/Xv2CoreLib/BAS/Deserializer.cs
+++ b/Xv2CoreLib/BAS/Deserializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Xv2CoreLib.BCS;
 using YAXLib;
 
 namespace Xv2CoreLib.BAS
@@ -43,7 +44,10 @@ namespace Xv2CoreLib.BAS
             bytes.AddRange(BitConverter.GetBytes(count));
             bytes.AddRange(BitConverter.GetBytes(16));
 
-            if(basFile.Entries != null)
+            if (basFile.Version > BAS_File.CURRENT_VERSION)
+                throw new InvalidDataException($"BAS: This BAS version is not supported (Version: {basFile.Version}).");
+
+            if (basFile.Entries != null)
             {
                 for(int i = 0; i < basFile.Entries.Count; i++)
                 {
@@ -89,6 +93,12 @@ namespace Xv2CoreLib.BAS
                             bytes.AddRange(BitConverter.GetBytes(basFile.Entries[i].SubEntries[a].F_72));
                             bytes.AddRange(BitConverter.GetBytes(basFile.Entries[i].SubEntries[a].F_76));
                             bytes.AddRange(BitConverter.GetBytes(basFile.Entries[i].SubEntries[a].F_80));
+
+                            if (basFile.Version >= 1)
+                                bytes.AddRange(BitConverter.GetBytes(basFile.Entries[i].SubEntries[a].I_84));
+
+                            if (basFile.Version >= 2)
+                                bytes.AddRange(BitConverter.GetBytes(basFile.Entries[i].SubEntries[a].I_88));
                         }
                     }
                 }

--- a/Xv2CoreLib/BAS/Parser.cs
+++ b/Xv2CoreLib/BAS/Parser.cs
@@ -40,7 +40,10 @@ namespace Xv2CoreLib.BAS
             int count = BitConverter.ToInt32(rawBytes, 8);
             int offset = BitConverter.ToInt32(rawBytes, 12);
 
-            if(count > 0)
+            basFile.Version = BAS_File.GetBasVersion(rawBytes.Length, BitConverter.ToInt32(rawBytes, offset + 4));
+            int entrySize = BAS_File.GetSubEntrySize(basFile.Version);
+
+            if (count > 0)
             {
                 basFile.Entries = new List<BAS_Entry>();
 
@@ -51,13 +54,13 @@ namespace Xv2CoreLib.BAS
                     int subEntryCount = BitConverter.ToInt32(rawBytes, offset + 4);
                     int subEntryOffset = BitConverter.ToInt32(rawBytes, offset + 8);
 
-                    if(subEntryCount > 0)
+                    if (subEntryCount > 0)
                     {
                         basFile.Entries[i].SubEntries = new List<BAS_SubEntry>();
 
-                        for(int a = 0; a < subEntryCount; a++)
+                        for (int a = 0; a < subEntryCount; a++)
                         {
-                            basFile.Entries[i].SubEntries.Add(new BAS_SubEntry()
+                            BAS_SubEntry subEntry = new BAS_SubEntry
                             {
                                 Name = StringEx.GetString(rawBytes, subEntryOffset, false, StringEx.EncodingType.ASCII, 8),
                                 I_08 = BitConverter_Ex.ToBooleanFromInt32(rawBytes, subEntryOffset + 8),
@@ -79,9 +82,21 @@ namespace Xv2CoreLib.BAS
                                 F_72 = BitConverter.ToSingle(rawBytes, subEntryOffset + 72),
                                 F_76 = BitConverter.ToSingle(rawBytes, subEntryOffset + 76),
                                 F_80 = BitConverter.ToSingle(rawBytes, subEntryOffset + 80),
-                            });
+                            };
 
-                            subEntryOffset += 84;
+                            if (basFile.Version >= 1)
+                            {
+                                subEntry.I_84 = BitConverter.ToInt32(rawBytes, subEntryOffset + 84);
+                            }
+
+                            if (basFile.Version >= 2)
+                            {
+                                subEntry.I_88 = BitConverter.ToInt32(rawBytes, subEntryOffset + 88);
+                            }
+
+                            basFile.Entries[i].SubEntries.Add(subEntry);
+
+                            subEntryOffset += entrySize;
                         }
 
                     }


### PR DESCRIPTION
Fixes the BAS file parser and implements a version check based on the entry size, to hopefully prevent issues with the parser when the format gets updated again