### PR TITLE
Rework installable FMP objects

### DIFF
--- a/Xv2CoreLib/FMP/FMP_File.cs
+++ b/Xv2CoreLib/FMP/FMP_File.cs
@@ -960,7 +960,7 @@ namespace Xv2CoreLib.FMP
     }
 
     [YAXSerializeAs("Object")]
-    public class FMP_Object
+    public class FMP_Object : IInstallable
     {
         [YAXAttributeForClass]
         [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
@@ -970,10 +970,12 @@ namespace Xv2CoreLib.FMP
         public string Name { get; set; }
 
         [YAXDontSerialize]
-        public string Name
+        public int SortID => Index;
+
+        string IInstallable.Index
         {
-            get => Index;
-            set => Index = value;
+            get => Index.ToString();
+            set => Index = int.Parse(value);
         }
 
         [CustomSerialize(isHex: true)]
@@ -2794,12 +2796,21 @@ namespace Xv2CoreLib.FMP
     }
 
     [YAXSerializeAs("CollisionGroup")]
-    public class FMP_CollisionGroup
+    public class FMP_CollisionGroup : IInstallable
     {
         [YAXAttributeForClass]
         public int Index { get; set; }
         [YAXAttributeForClass]
         public string Name { get; set; }
+
+        [YAXDontSerialize]
+        public int SortID => Index;
+
+        string IInstallable.Index
+        {
+            get => Index.ToString();
+            set => Index = int.Parse(value);
+        }
 
         [YAXCollection(YAXCollectionSerializationTypes.RecursiveWithNoContainingElement, EachElementName = "Collider")]
         public List<FMP_Collider> Colliders { get; set; } = new List<FMP_Collider>();

--- a/Xv2CoreLib/FMP/FMP_File.cs
+++ b/Xv2CoreLib/FMP/FMP_File.cs
@@ -969,6 +969,13 @@ namespace Xv2CoreLib.FMP
         [YAXAttributeForClass]
         public string Name { get; set; }
 
+        [YAXDontSerialize]
+        public string Name
+        {
+            get => Index;
+            set => Index = value;
+        }
+
         [CustomSerialize(isHex: true)]
         public ushort I_04 { get; set; }
 


### PR DESCRIPTION
Reworks how FMP objects and groups install, and keeps each object name alias instead of dropping it partway through. Makes FMP mods land predictably in a clean game.