### PR TITLE
Share BSA/BAC metadata and move file names for editing

### DIFF
--- a/Xv2CoreLib/BSA/BSA_File.cs
+++ b/Xv2CoreLib/BSA/BSA_File.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Xv2CoreLib.Resource;
@@ -306,6 +307,8 @@ namespace Xv2CoreLib.BSA
                 IBsaTypes.Add(bsaEntry);
             foreach (var bsaEntry in Type8)
                 IBsaTypes.Add(bsaEntry);
+            foreach (var bsaEntry in Type10)
+                IBsaTypes.Add(bsaEntry);
             foreach (var bsaEntry in Type12)
                 IBsaTypes.Add(bsaEntry);
             foreach (var bsaEntry in Type13)
@@ -353,6 +356,10 @@ namespace Xv2CoreLib.BSA
                 {
                     Type8.Add(type8);
                 }
+                else if (bsaEntry is BSA_Type10 type10)
+                {
+                    Type10.Add(type10);
+                }
                 else if (bsaEntry is BSA_Type12 type12)
                 {
                     Type12.Add(type12);
@@ -386,6 +393,8 @@ namespace Xv2CoreLib.BSA
                 Type7 = new List<BSA_Type7>();
             if (Type8 == null)
                 Type8 = new List<BSA_Type8>();
+            if (Type10 == null)
+                Type10 = new List<BSA_Type10>();
             if (Type12 == null)
                 Type12 = new List<BSA_Type12>();
             if (Type13 == null)
@@ -406,6 +415,7 @@ namespace Xv2CoreLib.BSA
             Type6.Clear();
             Type7.Clear();
             Type8.Clear();
+            Type10.Clear();
             Type12.Clear();
             Type13.Clear();
             Type14.Clear();
@@ -502,14 +512,17 @@ namespace Xv2CoreLib.BSA
     [YAXSerializeAs("BsaEntryPassing")]
     [BindingSubClass]
     [Serializable]
-    public class BSA_Type0 : IBsaType
+    public class BSA_Type0 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 0;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public short I_00 { get; set; }
@@ -536,14 +549,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("Movement")]
     [Serializable]
-    public class BSA_Type1 : IBsaType
+    public class BSA_Type1 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 1;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("Motion_Flags")]
         [YAXSerializeAs("value")]
         [YAXHexValue]
@@ -596,14 +612,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type2")]
     [Serializable]
-    public class BSA_Type2 : IBsaType
+    public class BSA_Type2 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 2;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public short I_00 { get; set; }
@@ -621,14 +640,17 @@ namespace Xv2CoreLib.BSA
     [YAXSerializeAs("Hitbox")]
     [BindingSubClass]
     [Serializable]
-    public class BSA_Type3 : IBsaType
+    public class BSA_Type3 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 3;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public UInt16 I_00 { get; set; }
@@ -719,14 +741,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("Deflection")]
     [Serializable]
-    public class BSA_Type4 : IBsaType
+    public class BSA_Type4 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 4;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public int I_00 { get; set; }
@@ -785,14 +810,17 @@ namespace Xv2CoreLib.BSA
     [YAXSerializeAs("Effect")]
     [BindingSubClass]
     [Serializable]
-    public class BSA_Type6 : IBsaType
+    public class BSA_Type6 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 6;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("EEPK")]
         [YAXSerializeAs("Type")]
         public EepkType EepkType { get; set; } //Int16
@@ -864,14 +892,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("Sound")]
     [Serializable]
-    public class BSA_Type7 : IBsaType
+    public class BSA_Type7 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 7;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("ACB_File")]
         [YAXSerializeAs("value")]
         public AcbType AcbType { get; set; } //int16
@@ -888,14 +919,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type8")]
     [Serializable]
-    public class BSA_Type8 : IBsaType
+    public class BSA_Type8 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 8;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public ushort I_00 { get; set; }
@@ -921,14 +955,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type10")]
     [Serializable]
-    public class BSA_Type10 : IBsaType
+    public class BSA_Type10 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 10;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("Skill_ID")]
         [YAXSerializeAs("value")]
         public int I_00 { get; set; }
@@ -944,14 +981,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type12")]
     [Serializable]
-    public class BSA_Type12 : IBsaType
+    public class BSA_Type12 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 12;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("F_00")]
         [YAXSerializeAs("value")]
         [YAXFormat("0.0##########")]
@@ -973,14 +1013,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type13")]
     [Serializable]
-    public class BSA_Type13 : IBsaType
+    public class BSA_Type13 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 13;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public ushort I_00 { get; set; }
@@ -1015,14 +1058,17 @@ namespace Xv2CoreLib.BSA
 
     [YAXSerializeAs("BSA_Type14")]
     [Serializable]
-    public class BSA_Type14 : IBsaType
+    public class BSA_Type14 : BSA_TypeBase
     {
+        [YAXDontSerialize]
+        public override int TypeID => 14;
+
         [YAXAttributeFor("Start_Time")]
         [YAXSerializeAs("frames")]
-        public ushort StartTime { get; set; }
+        public override ushort StartTime { get; set; }
         [YAXAttributeFor("Duration")]
         [YAXSerializeAs("frames")]
-        public ushort Duration { get; set; }
+        public override ushort Duration { get; set; }
         [YAXAttributeFor("I_00")]
         [YAXSerializeAs("value")]
         public ushort I_00 { get; set; }
@@ -1100,9 +1146,114 @@ namespace Xv2CoreLib.BSA
         public uint I_84 { get; set; }
     }
 
-    public interface IBsaType
+    public static class BsaTypeNames
+    {
+        public static string GetBaseName(IBsaType type)
+        {
+            switch (type)
+            {
+                case BSA_Type0 _:
+                    return "Entry Passing";
+                case BSA_Type1 _:
+                    return "Movement";
+                case BSA_Type2 _:
+                    return "Type2";
+                case BSA_Type3 _:
+                    return "Hitbox";
+                case BSA_Type4 _:
+                    return "Deflection";
+                case BSA_Type6 _:
+                    return "Effect";
+                case BSA_Type7 _:
+                    return "Sound";
+                case BSA_Type8 _:
+                    return "Screen Effect";
+                case BSA_Type10 _:
+                    return "Unknown 10";
+                case BSA_Type12 _:
+                    return "Unknown 12";
+                case BSA_Type13 _:
+                    return "Unknown 13";
+                case BSA_Type14 _:
+                    return "Unknown 14";
+                default:
+                    return type?.GetType().Name ?? string.Empty;
+            }
+        }
+
+        public static string GetName(IBsaType type)
+        {
+            switch (type)
+            {
+                case BSA_Type0 type0:
+                    return $"Entry Passing ({type0.BSA_EntryID}, 0x{type0.I_02:X}, {type0.F_08:0.###})";
+                case BSA_Type1 _:
+                    return "Movement";
+                case BSA_Type2 type2:
+                    return $"Type2 ({type2.I_00}, {type2.I_02}, {type2.I_04}, {type2.I_06})";
+                case BSA_Type3 _:
+                    return "Hitbox";
+                case BSA_Type4 type4:
+                    return $"Deflection ({type4.I_00}, {type4.I_04})";
+                case BSA_Type6 type6:
+                    return $"Effect ({type6.EepkType}, {type6.SkillID}, {type6.EffectID}, {type6.I_08})";
+                case BSA_Type7 type7:
+                    return $"Sound ({type7.AcbType}, {type7.CueId})";
+                case BSA_Type8 type8:
+                    return $"Screen Effect ({type8.I_00}, {type8.I_02})";
+                case BSA_Type10 type10:
+                    return $"Unknown 10 ({type10.I_00}, {type10.I_04}, {type10.I_06})";
+                case BSA_Type12 type12:
+                    return $"Unknown 12 ({type12.EepkType}, {type12.SkillID}, {type12.I_12})";
+                case BSA_Type13 type13:
+                    return $"Unknown 13 ({type13.I_00}, {type13.I_02}, {type13.I_12})";
+                case BSA_Type14 type14:
+                    return $"Unknown 14 ({type14.I_00}, {type14.I_02})";
+                default:
+                    return type?.GetType().Name ?? string.Empty;
+            }
+        }
+    }
+
+    [Serializable]
+    public abstract class BSA_TypeBase : IBsaType
+    {
+        [field: NonSerialized]
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public abstract ushort StartTime { get; set; }
+        public abstract ushort Duration { get; set; }
+
+        [YAXDontSerialize]
+        public abstract int TypeID { get; }
+
+        [YAXDontSerialize]
+        public virtual string Type => BsaTypeNames.GetName(this);
+
+        [YAXDontSerialize]
+        public virtual string TypeName => BsaTypeNames.GetBaseName(this);
+
+        public void RefreshType()
+        {
+            NotifyPropertyChanged(nameof(Type));
+            NotifyPropertyChanged(nameof(TypeName));
+            NotifyPropertyChanged(nameof(StartTime));
+            NotifyPropertyChanged(nameof(Duration));
+        }
+
+        protected void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public interface IBsaType : INotifyPropertyChanged
     {
         ushort StartTime { get; set; }
         ushort Duration { get; set; }
+        int TypeID { get; }
+        string Type { get; }
+        string TypeName { get; }
+        void RefreshType();
     }
 }

--- a/Xv2CoreLib/BSA/Deserializer.cs
+++ b/Xv2CoreLib/BSA/Deserializer.cs
@@ -175,84 +175,84 @@ namespace Xv2CoreLib.BSA
                 List<int> typeList = new List<int>();
 
                 //Type Headers
-                if(types.Type0 != null)
+                if(types.Type0?.Count > 0)
                 {
                     var results = WriteTypeHeader(0, types.Type0.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(0);
                 }
-                if (types.Type1 != null)
+                if (types.Type1?.Count > 0)
                 {
                     var results = WriteTypeHeader(1, types.Type1.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(1);
                 }
-                if (types.Type2 != null)
+                if (types.Type2?.Count > 0)
                 {
                     var results = WriteTypeHeader(2, types.Type2.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(2);
                 }
-                if (types.Type3 != null)
+                if (types.Type3?.Count > 0)
                 {
                     var results = WriteTypeHeader(3, types.Type3.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(3);
                 }
-                if (types.Type4 != null)
+                if (types.Type4?.Count > 0)
                 {
                     var results = WriteTypeHeader(4, types.Type4.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(4);
                 }
-                if (types.Type6 != null)
+                if (types.Type6?.Count > 0)
                 {
                     var results = WriteTypeHeader(6, types.Type6.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(6);
                 }
-                if (types.Type7 != null)
+                if (types.Type7?.Count > 0)
                 {
                     var results = WriteTypeHeader(7, types.Type7.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(7);
                 }
-                if (types.Type8 != null)
+                if (types.Type8?.Count > 0)
                 {
                     var results = WriteTypeHeader(8, types.Type8.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(8);
                 }
-                if (types.Type10 != null)
+                if (types.Type10?.Count > 0)
                 {
-                    var results = WriteTypeHeader(8, types.Type10.Count);
+                    var results = WriteTypeHeader(10, types.Type10.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(10);
                 }
-                if (types.Type12 != null)
+                if (types.Type12?.Count > 0)
                 {
                     var results = WriteTypeHeader(12, types.Type12.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(12);
                 }
-                if (types.Type13 != null)
+                if (types.Type13?.Count > 0)
                 {
                     var results = WriteTypeHeader(13, types.Type13.Count);
                     hdrOffset.Add(results[0]);
                     dataOffset.Add(results[1]);
                     typeList.Add(13);
                 }
-                if (types.Type14 != null)
+                if (types.Type14?.Count > 0)
                 {
                     var results = WriteTypeHeader(14, types.Type14.Count);
                     hdrOffset.Add(results[0]);
@@ -752,51 +752,51 @@ namespace Xv2CoreLib.BSA
         private int BsaTypeCount(BSA_Entry bsaEntry)
         {
             int count = 0;
-            if(bsaEntry.Type0 != null)
+            if(bsaEntry.Type0?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type1 != null)
+            if (bsaEntry.Type1?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type2 != null)
+            if (bsaEntry.Type2?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type3 != null)
+            if (bsaEntry.Type3?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type4 != null)
+            if (bsaEntry.Type4?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type6 != null)
+            if (bsaEntry.Type6?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type7 != null)
+            if (bsaEntry.Type7?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type8 != null)
+            if (bsaEntry.Type8?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type10 != null)
+            if (bsaEntry.Type10?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type12 != null)
+            if (bsaEntry.Type12?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type13 != null)
+            if (bsaEntry.Type13?.Count > 0)
             {
                 count++;
             }
-            if (bsaEntry.Type14 != null)
+            if (bsaEntry.Type14?.Count > 0)
             {
                 count++;
             }

--- a/Xv2CoreLib/ValuesDictionary/BAC.cs
+++ b/Xv2CoreLib/ValuesDictionary/BAC.cs
@@ -271,7 +271,8 @@ namespace Xv2CoreLib.ValuesDictionary
         public static Dictionary<byte, string> BsaSpawnOrientation { get; private set; } = new Dictionary<byte, string>()
         {
             { 0 , "Default" },
-            { 3 , "User Direction" }
+            { 1 , "User Direction (1)" },
+            { 3 , "User Direction (3)" }
         };
 
         //Targeting Assistance

--- a/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
+++ b/Xv2CoreLib/Xenoverse2/Xenoverse2.cs
@@ -669,7 +669,7 @@ namespace Xv2CoreLib
                     moveFiles.AfterBcmPath = String.Format("{0}/{1}/{1}_AFTER_PLAYER.bcm", skillDir, folderName);
 
                     if (loadSkillFiles)
-                        moveFiles.AfterBcmFile = new Xv2File<BCM_File>((BCM_File)FileManager.Instance.GetParsedFileFromGame(moveFiles.AfterBcmPath, loadFromCpk), fileIO.PathInGameDir(moveFiles.AfterBcmPath), false, null, false, MoveFileTypes.BCM, 0, false, MoveType.Skill);
+                        moveFiles.AfterBcmFile = new Xv2File<BCM_File>((BCM_File)FileManager.Instance.GetParsedFileFromGame(moveFiles.AfterBcmPath, loadFromCpk), fileIO.PathInGameDir(moveFiles.AfterBcmPath), false, null, false, MoveFileTypes.AFTER_BCM, 0, false, MoveType.Skill);
                 }
                 else
                 {
@@ -677,7 +677,7 @@ namespace Xv2CoreLib
                     moveFiles.AfterBcmPath = String.Format("skill/{0}.bcm", cusEntry.AfterBcmPath);
 
                     if (loadSkillFiles)
-                        moveFiles.AfterBcmFile = new Xv2File<BCM_File>((BCM_File)FileManager.Instance.GetParsedFileFromGame(moveFiles.AfterBcmPath, loadFromCpk), fileIO.PathInGameDir(moveFiles.AfterBcmPath), true, null, false, MoveFileTypes.BCM, 0, false, MoveType.Skill);
+                        moveFiles.AfterBcmFile = new Xv2File<BCM_File>((BCM_File)FileManager.Instance.GetParsedFileFromGame(moveFiles.AfterBcmPath, loadFromCpk), fileIO.PathInGameDir(moveFiles.AfterBcmPath), true, null, false, MoveFileTypes.AFTER_BCM, 0, false, MoveType.Skill);
                 }
             }
 

--- a/Xv2CoreLib/Xenoverse2/Xv2File.cs
+++ b/Xv2CoreLib/Xenoverse2/Xv2File.cs
@@ -75,7 +75,17 @@ namespace Xv2CoreLib
                     case MoveFileTypes.BAC:
                         return Costumes.Count == 1 ? System.IO.Path.GetFileNameWithoutExtension(Path) : "Main";
                     case MoveFileTypes.AFTER_BAC:
-                        return "AFTER";
+                        return "After Action";
+                    case MoveFileTypes.BCM:
+                        return "State";
+                    case MoveFileTypes.AFTER_BCM:
+                        return "After State";
+                    case MoveFileTypes.BDM:
+                        return "Hitbox";
+                    case MoveFileTypes.SHOT_BDM:
+                        return "Shot Hitbox";
+                    case MoveFileTypes.BSA:
+                        return "Projectile";
                     default:
                         return "";
                 }

--- a/Xv2CoreLib/Xenoverse2/Xv2File.cs
+++ b/Xv2CoreLib/Xenoverse2/Xv2File.cs
@@ -73,23 +73,32 @@ namespace Xv2CoreLib
                                 return "invalid_ACB_Type";
                         }
                     case MoveFileTypes.BAC:
-                        return Costumes.Count == 1 ? System.IO.Path.GetFileNameWithoutExtension(Path) : "Main";
+                        return GetFileNameOrDefault(Costumes.Count == 1 ? "Action" : "Main");
                     case MoveFileTypes.AFTER_BAC:
-                        return "After Action";
+                        return GetFileNameOrDefault("After Action");
                     case MoveFileTypes.BCM:
-                        return "State";
+                        return GetFileNameOrDefault("State");
                     case MoveFileTypes.AFTER_BCM:
-                        return "After State";
+                        return GetFileNameOrDefault("After State");
                     case MoveFileTypes.BDM:
-                        return "Hitbox";
+                        return GetFileNameOrDefault("Hitbox");
                     case MoveFileTypes.SHOT_BDM:
-                        return "Shot Hitbox";
+                        return GetFileNameOrDefault("Shot Hitbox");
                     case MoveFileTypes.BSA:
-                        return "Projectile";
+                        return GetFileNameOrDefault("Projectile");
                     default:
                         return "";
                 }
             }
+        }
+
+        private string GetFileNameOrDefault(string defaultName)
+        {
+            if (string.IsNullOrWhiteSpace(Path))
+                return defaultName;
+
+            string fileName = System.IO.Path.GetFileNameWithoutExtension(Path);
+            return string.IsNullOrWhiteSpace(fileName) ? defaultName : fileName;
         }
 
         #endregion

--- a/Xv2CoreLib/bin/Debug/System.Numerics.Vectors.xml
+++ b/Xv2CoreLib/bin/Debug/System.Numerics.Vectors.xml
@@ -1,2621 +1,3451 @@
-﻿<?xml version="1.0" encoding="utf-8"?><doc>
-  <assembly>
-    <name>System.Numerics.Vectors</name>
-  </assembly>
-  <members>
-    <member name="T:System.Numerics.Matrix3x2">
-      <summary>Represents a 3x2 matrix.</summary>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a 3x2 matrix from the specified components.</summary>
-      <param name="m11">The value to assign to the first element in the first row.</param>
-      <param name="m12">The value to assign to the second element in the first row.</param>
-      <param name="m21">The value to assign to the first element in the second row.</param>
-      <param name="m22">The value to assign to the second element in the second row.</param>
-      <param name="m31">The value to assign to the first element in the third row.</param>
-      <param name="m32">The value to assign to the second element in the third row.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Add(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single)">
-      <summary>Creates a rotation matrix using the given rotation in radians.</summary>
-      <param name="radians">The amount of rotation, in radians.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single,System.Numerics.Vector2)">
-      <summary>Creates a rotation matrix using the specified rotation in radians and a center point.</summary>
-      <param name="radians">The amount of rotation, in radians.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single)">
-      <summary>Creates a scaling matrix from the specified X and Y components.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix that scales uniformly with the specified scale with an offset from the specified center.</summary>
-      <param name="scale">The uniform scale to use.</param>
-      <param name="centerPoint">The center offset.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix that is offset by a given center point.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single)">
-      <summary>Creates a scaling matrix that scales uniformly with the given scale.</summary>
-      <param name="scale">The uniform scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix from the specified vector scale.</summary>
-      <param name="scales">The scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix from the specified vector scale with an offset from the specified center point.</summary>
-      <param name="scales">The scale to use.</param>
-      <param name="centerPoint">The center offset.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single)">
-      <summary>Creates a skew matrix from the specified angles in radians.</summary>
-      <param name="radiansX">The X angle, in radians.</param>
-      <param name="radiansY">The Y angle, in radians.</param>
-      <returns>The skew matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single,System.Numerics.Vector2)">
-      <summary>Creates a skew matrix from the specified angles in radians and a center point.</summary>
-      <param name="radiansX">The X angle, in radians.</param>
-      <param name="radiansY">The Y angle, in radians.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The skew matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Numerics.Vector2)">
-      <summary>Creates a translation matrix from the specified 2-dimensional vector.</summary>
-      <param name="position">The translation position.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Single,System.Single)">
-      <summary>Creates a translation matrix from the specified X and Y components.</summary>
-      <param name="xPosition">The X position.</param>
-      <param name="yPosition">The Y position.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Equals(System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether this instance and another 3x2 matrix are equal.</summary>
-      <param name="other">The other matrix.</param>
-      <returns>true if the two matrices are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.GetDeterminant">
-      <summary>Calculates the determinant for this matrix.</summary>
-      <returns>The determinant.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.Identity">
-      <summary>Gets the multiplicative identity matrix.</summary>
-      <returns>The multiplicative identify matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Invert(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2@)">
-      <summary>Inverts the specified matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The matrix to invert.</param>
-      <param name="result">When this method returns, contains the inverted matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was converted successfully; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.IsIdentity">
-      <summary>Indicates whether the current matrix is the identity matrix.</summary>
-      <returns>true if the current matrix is the identity matrix; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Lerp(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2,System.Single)">
-      <summary>Performs a linear interpolation from one matrix to a second matrix based on a value that specifies the weighting of the second matrix.</summary>
-      <param name="matrix1">The first matrix.</param>
-      <param name="matrix2">The second matrix.</param>
-      <param name="amount">The relative weighting of matrix2.</param>
-      <returns>The interpolated matrix.</returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M11">
-      <summary>The first element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M12">
-      <summary>The second element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M21">
-      <summary>The first element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M22">
-      <summary>The second element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M31">
-      <summary>The first element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M32">
-      <summary>The second element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Negate(System.Numerics.Matrix3x2)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Addition(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Equality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether the specified matrices are equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Inequality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether the specified matrices are not equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Subtraction(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_UnaryNegation(System.Numerics.Matrix3x2)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Subtract(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.ToString">
-      <summary>Returns a string that represents this matrix.</summary>
-      <returns>The string representation of this matrix.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.Translation">
-      <summary>Gets or sets the translation component of this matrix.</summary>
-      <returns>The translation component of the current instance.</returns>
-    </member>
-    <member name="T:System.Numerics.Matrix4x4">
-      <summary>Represents a 4x4 matrix.</summary>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.#ctor(System.Numerics.Matrix3x2)">
-      <summary>Creates a <see cref="T:System.Numerics.Matrix4x4"></see> object from a specified <see cref="T:System.Numerics.Matrix3x2"></see> object.</summary>
-      <param name="value">A 3x2 matrix.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a 4x4 matrix from the specified components.</summary>
-      <param name="m11">The value to assign to the first element in the first row.</param>
-      <param name="m12">The value to assign to the second element in the first row.</param>
-      <param name="m13">The value to assign to the third element in the first row.</param>
-      <param name="m14">The value to assign to the fourth element in the first row.</param>
-      <param name="m21">The value to assign to the first element in the second row.</param>
-      <param name="m22">The value to assign to the second element in the second row.</param>
-      <param name="m23">The value to assign to the third element in the second row.</param>
-      <param name="m24">The value to assign to the third element in the second row.</param>
-      <param name="m31">The value to assign to the first element in the third row.</param>
-      <param name="m32">The value to assign to the second element in the third row.</param>
-      <param name="m33">The value to assign to the third element in the third row.</param>
-      <param name="m34">The value to assign to the fourth element in the third row.</param>
-      <param name="m41">The value to assign to the first element in the fourth row.</param>
-      <param name="m42">The value to assign to the second element in the fourth row.</param>
-      <param name="m43">The value to assign to the third element in the fourth row.</param>
-      <param name="m44">The value to assign to the fourth element in the fourth row.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Add(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a spherical billboard that rotates around a specified object position.</summary>
-      <param name="objectPosition">The position of the object that the billboard will rotate around.</param>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="cameraUpVector">The up vector of the camera.</param>
-      <param name="cameraForwardVector">The forward vector of the camera.</param>
-      <returns>The created billboard.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateConstrainedBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a cylindrical billboard that rotates around a specified axis.</summary>
-      <param name="objectPosition">The position of the object that the billboard will rotate around.</param>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="rotateAxis">The axis to rotate the billboard around.</param>
-      <param name="cameraForwardVector">The forward vector of the camera.</param>
-      <param name="objectForwardVector">The forward vector of the object.</param>
-      <returns>The billboard matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a matrix that rotates around an arbitrary vector.</summary>
-      <param name="axis">The axis to rotate around.</param>
-      <param name="angle">The angle to rotate around axis, in radians.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromQuaternion(System.Numerics.Quaternion)">
-      <summary>Creates a rotation matrix from the specified Quaternion rotation value.</summary>
-      <param name="quaternion">The source Quaternion.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
-      <summary>Creates a rotation matrix from the specified yaw, pitch, and roll.</summary>
-      <param name="yaw">The angle of rotation, in radians, around the Y axis.</param>
-      <param name="pitch">The angle of rotation, in radians, around the X axis.</param>
-      <param name="roll">The angle of rotation, in radians, around the Z axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateLookAt(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a view matrix.</summary>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="cameraTarget">The target towards which the camera is pointing.</param>
-      <param name="cameraUpVector">The direction that is &amp;quot;up&amp;quot; from the camera&amp;#39;s point of view.</param>
-      <returns>The view matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateOrthographic(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates an orthographic perspective matrix from the given view volume dimensions.</summary>
-      <param name="width">The width of the view volume.</param>
-      <param name="height">The height of the view volume.</param>
-      <param name="zNearPlane">The minimum Z-value of the view volume.</param>
-      <param name="zFarPlane">The maximum Z-value of the view volume.</param>
-      <returns>The orthographic projection matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateOrthographicOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a customized orthographic projection matrix.</summary>
-      <param name="left">The minimum X-value of the view volume.</param>
-      <param name="right">The maximum X-value of the view volume.</param>
-      <param name="bottom">The minimum Y-value of the view volume.</param>
-      <param name="top">The maximum Y-value of the view volume.</param>
-      <param name="zNearPlane">The minimum Z-value of the view volume.</param>
-      <param name="zFarPlane">The maximum Z-value of the view volume.</param>
-      <returns>The orthographic projection matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspective(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a perspective projection matrix from the given view volume dimensions.</summary>
-      <param name="width">The width of the view volume at the near view plane.</param>
-      <param name="height">The height of the view volume at the near view plane.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances.</summary>
-      <param name="fieldOfView">The field of view in the y direction, in radians.</param>
-      <param name="aspectRatio">The aspect ratio, defined as view space width divided by height.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fieldOfView">fieldOfView</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="fieldOfView">fieldOfView</paramref> is greater than or equal to <see cref="System.Math.PI"></see>.  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a customized perspective projection matrix.</summary>
-      <param name="left">The minimum x-value of the view volume at the near view plane.</param>
-      <param name="right">The maximum x-value of the view volume at the near view plane.</param>
-      <param name="bottom">The minimum y-value of the view volume at the near view plane.</param>
-      <param name="top">The maximum y-value of the view volume at the near view plane.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateReflection(System.Numerics.Plane)">
-      <summary>Creates a matrix that reflects the coordinate system about a specified plane.</summary>
-      <param name="value">The plane about which to create a reflection.</param>
-      <returns>A new matrix expressing the reflection.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single)">
-      <summary>Creates a matrix for rotating points around the X axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the X axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a matrix for rotating points around the X axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the X axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single,System.Numerics.Vector3)">
-      <summary>The amount, in radians, by which to rotate around the Y axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single)">
-      <summary>Creates a matrix for rotating points around the Y axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single)">
-      <summary>Creates a matrix for rotating points around the Z axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a matrix for rotating points around the Z axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix from the specified vector scale.</summary>
-      <param name="scales">The scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single)">
-      <summary>Creates a uniform scaling matrix that scale equally on each axis.</summary>
-      <param name="scale">The uniform scaling factor.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix with a center point.</summary>
-      <param name="scales">The vector that contains the amount to scale on each axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a uniform scaling matrix that scales equally on each axis with a center point.</summary>
-      <param name="scale">The uniform scaling factor.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single)">
-      <summary>Creates a scaling matrix from the specified X, Y, and Z components.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="zScale">The value to scale by on the Z axis.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single,System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix that is offset by a given center point.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="zScale">The value to scale by on the Z axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateShadow(System.Numerics.Vector3,System.Numerics.Plane)">
-      <summary>Creates a matrix that flattens geometry into a specified plane as if casting a shadow from a specified light source.</summary>
-      <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
-      <param name="plane">The plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
-      <returns>A new matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Numerics.Vector3)">
-      <summary>Creates a translation matrix from the specified 3-dimensional vector.</summary>
-      <param name="position">The amount to translate in each axis.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Single,System.Single,System.Single)">
-      <summary>Creates a translation matrix from the specified X, Y, and Z components.</summary>
-      <param name="xPosition">The amount to translate on the X axis.</param>
-      <param name="yPosition">The amount to translate on the Y axis.</param>
-      <param name="zPosition">The amount to translate on the Z axis.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateWorld(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a world matrix with the specified parameters.</summary>
-      <param name="position">The position of the object.</param>
-      <param name="forward">The forward direction of the object.</param>
-      <param name="up">The upward direction of the object. Its value is usually [0, 1, 0].</param>
-      <returns>The world matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Decompose(System.Numerics.Matrix4x4,System.Numerics.Vector3@,System.Numerics.Quaternion@,System.Numerics.Vector3@)">
-      <summary>Attempts to extract the scale, translation, and rotation components from the given scale, rotation, or translation matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The source matrix.</param>
-      <param name="scale">When this method returns, contains the scaling component of the transformation matrix if the operation succeeded.</param>
-      <param name="rotation">When this method returns, contains the rotation component of the transformation matrix if the operation succeeded.</param>
-      <param name="translation">When the method returns, contains the translation component of the transformation matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was decomposed successfully; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Equals(System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether this instance and another 4x4 matrix are equal.</summary>
-      <param name="other">The other matrix.</param>
-      <returns>true if the two matrices are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.GetDeterminant">
-      <summary>Calculates the determinant of the current 4x4 matrix.</summary>
-      <returns>The determinant.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.Identity">
-      <summary>Gets the multiplicative identity matrix.</summary>
-      <returns>Gets the multiplicative identity matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Invert(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4@)">
-      <summary>Inverts the specified matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The matrix to invert.</param>
-      <param name="result">When this method returns, contains the inverted matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was converted successfully; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.IsIdentity">
-      <summary>Indicates whether the current matrix is the identity matrix.</summary>
-      <returns>true if the current matrix is the identity matrix; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,System.Single)">
-      <summary>Performs a linear interpolation from one matrix to a second matrix based on a value that specifies the weighting of the second matrix.</summary>
-      <param name="matrix1">The first matrix.</param>
-      <param name="matrix2">The second matrix.</param>
-      <param name="amount">The relative weighting of matrix2.</param>
-      <returns>The interpolated matrix.</returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M11">
-      <summary>The first element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M12">
-      <summary>The second element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M13">
-      <summary>The third element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M14">
-      <summary>The fourth element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M21">
-      <summary>The first element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M22">
-      <summary>The second element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M23">
-      <summary>The third element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M24">
-      <summary>The fourth element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M31">
-      <summary>The first element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M32">
-      <summary>The second element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M33">
-      <summary>The third element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M34">
-      <summary>The fourth element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M41">
-      <summary>The first element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M42">
-      <summary>The second element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M43">
-      <summary>The third element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M44">
-      <summary>The fourth element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Negate(System.Numerics.Matrix4x4)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Addition(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Equality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether the specified matrices are equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to care</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Inequality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether the specified matrices are not equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Subtraction(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_UnaryNegation(System.Numerics.Matrix4x4)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Subtract(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.ToString">
-      <summary>Returns a string that represents this matrix.</summary>
-      <returns>The string representation of this matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Transform(System.Numerics.Matrix4x4,System.Numerics.Quaternion)">
-      <summary>Transforms the specified matrix by applying the specified Quaternion rotation.</summary>
-      <param name="value">The matrix to transform.</param>
-      <param name="rotation">The rotation t apply.</param>
-      <returns>The transformed matrix.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.Translation">
-      <summary>Gets or sets the translation component of this matrix.</summary>
-      <returns>The translation component of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Transpose(System.Numerics.Matrix4x4)">
-      <summary>Transposes the rows and columns of a matrix.</summary>
-      <param name="matrix">The matrix to transpose.</param>
-      <returns>The transposed matrix.</returns>
-    </member>
-    <member name="T:System.Numerics.Plane">
-      <summary>Represents a three-dimensional plane.</summary>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector4)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from a specified four-dimensional vector.</summary>
-      <param name="value">A vector whose first three elements describe the normal vector, and whose <see cref="F:System.Numerics.Vector4.W"></see> defines the distance along that normal from the origin.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from a specified normal and the distance along the normal from the origin.</summary>
-      <param name="normal">The plane&amp;#39;s normal vector.</param>
-      <param name="d">The plane&amp;#39;s distance from the origin along its normal vector.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from the X, Y, and Z components of its normal, and its distance from the origin on that normal.</summary>
-      <param name="x">The X component of the normal.</param>
-      <param name="y">The Y component of the normal.</param>
-      <param name="z">The Z component of the normal.</param>
-      <param name="d">The distance of the plane along its normal from the origin.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.CreateFromVertices(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object that contains three specified points.</summary>
-      <param name="point1">The first point defining the plane.</param>
-      <param name="point2">The second point defining the plane.</param>
-      <param name="point3">The third point defining the plane.</param>
-      <returns>The plane containing the three points.</returns>
-    </member>
-    <member name="F:System.Numerics.Plane.D">
-      <summary>The distance of the plane along its normal from the origin.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Dot(System.Numerics.Plane,System.Numerics.Vector4)">
-      <summary>Calculates the dot product of a plane and a 4-dimensional vector.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The four-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.DotCoordinate(System.Numerics.Plane,System.Numerics.Vector3)">
-      <summary>Returns the dot product of a specified three-dimensional vector and the normal vector of this plane plus the distance (<see cref="F:System.Numerics.Plane.D"></see>) value of the plane.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The 3-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.DotNormal(System.Numerics.Plane,System.Numerics.Vector3)">
-      <summary>Returns the dot product of a specified three-dimensional vector and the <see cref="F:System.Numerics.Plane.Normal"></see> vector of this plane.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The three-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Equals(System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether this instance and another plane object are equal.</summary>
-      <param name="other">The other plane.</param>
-      <returns>true if the two planes are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="F:System.Numerics.Plane.Normal">
-      <summary>The normal vector of the plane.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Normalize(System.Numerics.Plane)">
-      <summary>Creates a new <see cref="T:System.Numerics.Plane"></see> object whose normal vector is the source plane&amp;#39;s normal vector normalized.</summary>
-      <param name="value">The source plane.</param>
-      <returns>The normalized plane.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.op_Equality(System.Numerics.Plane,System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether two planes are equal.</summary>
-      <param name="value1">The first plane to compare.</param>
-      <param name="value2">The second plane to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.op_Inequality(System.Numerics.Plane,System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether two planes are not equal.</summary>
-      <param name="value1">The first plane to compare.</param>
-      <param name="value2">The second plane to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.ToString">
-      <summary>Returns the string representation of this plane object.</summary>
-      <returns>A string that represents this <see cref="System.Numerics.Plane"></see> object.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Matrix4x4)">
-      <summary>Transforms a normalized plane by a 4x4 matrix.</summary>
-      <param name="plane">The normalized plane to transform.</param>
-      <param name="matrix">The transformation matrix to apply to plane.</param>
-      <returns>The transformed plane.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Quaternion)">
-      <summary>Transforms a normalized plane by a Quaternion rotation.</summary>
-      <param name="plane">The normalized plane to transform.</param>
-      <param name="rotation">The Quaternion rotation to apply to the plane.</param>
-      <returns>A new plane that results from applying the Quaternion rotation.</returns>
-    </member>
-    <member name="T:System.Numerics.Quaternion">
-      <summary>Represents a vector that is used to encode three-dimensional physical rotations.</summary>
-    </member>
-    <member name="M:System.Numerics.Quaternion.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a quaternion from the specified vector and rotation parts.</summary>
-      <param name="vectorPart">The vector part of the quaternion.</param>
-      <param name="scalarPart">The rotation part of the quaternion.</param>
-    </member>
-    <member name="M:System.Numerics.Quaternion.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Constructs a quaternion from the specified components.</summary>
-      <param name="x">The value to assign to the X component of the quaternion.</param>
-      <param name="y">The value to assign to the Y component of the quaternion.</param>
-      <param name="z">The value to assign to the Z component of the quaternion.</param>
-      <param name="w">The value to assign to the W component of the quaternion.</param>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Add(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Adds each element in one quaternion with its corresponding element in a second quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Concatenate(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Concatenates two quaternions.</summary>
-      <param name="value1">The first quaternion rotation in the series.</param>
-      <param name="value2">The second quaternion rotation in the series.</param>
-      <returns>A new quaternion representing the concatenation of the <paramref name="value1">value1</paramref> rotation followed by the <paramref name="value2">value2</paramref> rotation.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Conjugate(System.Numerics.Quaternion)">
-      <summary>Returns the conjugate of a specified quaternion.</summary>
-      <param name="value">The quaternion.</param>
-      <returns>A new quaternion that is the conjugate of value.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a quaternion from a vector and an angle to rotate about the vector.</summary>
-      <param name="axis">The vector to rotate around.</param>
-      <param name="angle">The angle, in radians, to rotate around the vector.</param>
-      <returns>The newly created quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromRotationMatrix(System.Numerics.Matrix4x4)">
-      <summary>Creates a quaternion from the specified rotation matrix.</summary>
-      <param name="matrix">The rotation matrix.</param>
-      <returns>The newly created quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
-      <summary>Creates a new quaternion from the given yaw, pitch, and roll.</summary>
-      <param name="yaw">The yaw angle, in radians, around the Y axis.</param>
-      <param name="pitch">The pitch angle, in radians, around the X axis.</param>
-      <param name="roll">The roll angle, in radians, around the Z axis.</param>
-      <returns>The resulting quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Divide(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Divides one quaternion by a second quaternion.</summary>
-      <param name="value1">The dividend.</param>
-      <param name="value2">The divisor.</param>
-      <returns>The quaternion that results from dividing <paramref name="value1">value1</paramref> by <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Dot(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Calculates the dot product of two quaternions.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Equals(System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether this instance and another quaternion are equal.</summary>
-      <param name="other">The other quaternion.</param>
-      <returns>true if the two quaternions are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Quaternion.Identity">
-      <summary>Gets a quaternion that represents no rotation.</summary>
-      <returns>A quaternion whose values are (0, 0, 0, 1).</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Inverse(System.Numerics.Quaternion)">
-      <summary>Returns the inverse of a quaternion.</summary>
-      <param name="value">The quaternion.</param>
-      <returns>The inverted quaternion.</returns>
-    </member>
-    <member name="P:System.Numerics.Quaternion.IsIdentity">
-      <summary>Gets a value that indicates whether the current instance is the identity quaternion.</summary>
-      <returns>true if the current instance is the identity quaternion; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Length">
-      <summary>Calculates the length of the quaternion.</summary>
-      <returns>The computed length of the quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.LengthSquared">
-      <summary>Calculates the squared length of the quaternion.</summary>
-      <returns>The length squared of the quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Lerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
-      <summary>Performs a linear interpolation between two quaternions based on a value that specifies the weighting of the second quaternion.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <param name="amount">The relative weight of quaternion2 in the interpolation.</param>
-      <returns>The interpolated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns the quaternion that results from multiplying two quaternions together.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The product quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Single)">
-      <summary>Returns the quaternion that results from scaling all the components of a specified quaternion by a scalar factor.</summary>
-      <param name="value1">The source quaternion.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The scaled quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Negate(System.Numerics.Quaternion)">
-      <summary>Reverses the sign of each component of the quaternion.</summary>
-      <param name="value">The quaternion to negate.</param>
-      <returns>The negated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Normalize(System.Numerics.Quaternion)">
-      <summary>Divides each component of a specified <see cref="T:System.Numerics.Quaternion"></see> by its length.</summary>
-      <param name="value">The quaternion to normalize.</param>
-      <returns>The normalized quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Addition(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Adds each element in one quaternion with its corresponding element in a second quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Division(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Divides one quaternion by a second quaternion.</summary>
-      <param name="value1">The dividend.</param>
-      <param name="value2">The divisor.</param>
-      <returns>The quaternion that results from dividing <paramref name="value1">value1</paramref> by <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Equality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether two quaternions are equal.</summary>
-      <param name="value1">The first quaternion to compare.</param>
-      <param name="value2">The second quaternion to compare.</param>
-      <returns>true if the two quaternions are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Inequality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether two quaternions are not equal.</summary>
-      <param name="value1">The first quaternion to compare.</param>
-      <param name="value2">The second quaternion to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Single)">
-      <summary>Returns the quaternion that results from scaling all the components of a specified quaternion by a scalar factor.</summary>
-      <param name="value1">The source quaternion.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The scaled quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns the quaternion that results from multiplying two quaternions together.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The product quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Subtraction(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Subtracts each element in a second quaternion from its corresponding element in a first quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_UnaryNegation(System.Numerics.Quaternion)">
-      <summary>Reverses the sign of each component of the quaternion.</summary>
-      <param name="value">The quaternion to negate.</param>
-      <returns>The negated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Slerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
-      <summary>Interpolates between two quaternions, using spherical linear interpolation.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <param name="amount">The relative weight of the second quaternion in the interpolation.</param>
-      <returns>The interpolated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Subtract(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Subtracts each element in a second quaternion from its corresponding element in a first quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.ToString">
-      <summary>Returns a string that represents this quaternion.</summary>
-      <returns>The string representation of this quaternion.</returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.W">
-      <summary>The rotation component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.X">
-      <summary>The X value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.Y">
-      <summary>The Y value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.Z">
-      <summary>The Z value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="T:System.Numerics.Vector`1">
-      <summary>Represents a single vector of a specified numeric type that is suitable for low-level optimization of parallel algorithms.</summary>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0)">
-      <summary>Creates a vector whose components are of a specified type.</summary>
-      <param name="value">The numeric type that defines the type of the components in the vector.</param>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0[])">
-      <summary>Creates a vector from a specified array.</summary>
-      <param name="values">A numeric array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="values">values</paramref> is null.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0[],System.Int32)">
-      <summary>Creates a vector from a specified array starting at a specified index position.</summary>
-      <param name="values">A numeric array.</param>
-      <param name="index">The starting index position from which to create the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="values">values</paramref> is null.</exception>
-      <exception cref="T:System.IndexOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- The length of <paramref name="values">values</paramref> minus <paramref name="index">index</paramref> is less than <see cref="System.Numerics.Vector`1.Count"></see>.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.CopyTo(`0[])">
-      <summary>Copies the vector instance to a specified destination array.</summary>
-      <param name="destination">The array to receive a copy of the vector values.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="destination">destination</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current vector is greater than the number of elements available in the <paramref name="destination">destination</paramref> array.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.CopyTo(`0[],System.Int32)">
-      <summary>Copies the vector instance to a specified destination array starting at a specified index position.</summary>
-      <param name="destination">The array to receive a copy of the vector values.</param>
-      <param name="startIndex">The starting index in destination at which to begin the copy operation.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="destination">destination</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than the number of elements available from <paramref name="startIndex">startIndex</paramref> to the end of the <paramref name="destination">destination</paramref> array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero or greater than the last index in <paramref name="destination">destination</paramref>.</exception>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Count">
-      <summary>Returns the number of elements stored in the vector.</summary>
-      <returns>The number of elements stored in the vector.</returns>
-      <exception cref="T:System.NotSupportedException">Access to the property getter via reflection is not supported.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.Equals(System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether this instance is equal to a specified vector.</summary>
-      <param name="other">The vector to compare with this instance.</param>
-      <returns>true if the current instance and <paramref name="other">other</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance is equal to a specified object.</summary>
-      <param name="obj">The object to compare with this instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. The method returns false if <paramref name="obj">obj</paramref> is null, or if <paramref name="obj">obj</paramref> is a vector of a different type than the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Item(System.Int32)">
-      <summary>Gets the element at a specified index.</summary>
-      <param name="index">The index of the element to return.</param>
-      <returns>The element at index <paramref name="index">index</paramref>.</returns>
-      <exception cref="T:System.IndexOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to <see cref="System.Numerics.Vector`1.Count"></see>.</exception>
-    </member>
-    <member name="P:System.Numerics.Vector`1.One">
-      <summary>Returns a vector containing all ones.</summary>
-      <returns>A vector containing all ones.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Addition(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_BitwiseAnd(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise And operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise And of <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_BitwiseOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise Or operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise Or of the elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Division(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Equality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_ExclusiveOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise XOr operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise XOr of the elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt64}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt64"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt32}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt32"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt16}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt16"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Single}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Single"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.SByte}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.SByte"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Double}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Double"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int32}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int32"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int16}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int16"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Byte}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Byte"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int64}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int64"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Inequality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether any single pair of elements in the specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if any element pairs in left and right are equal. false if no element pairs are equal.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},`0)">
-      <summary>Multiplies a vector by a specified scalar value.</summary>
-      <param name="value">The source vector.</param>
-      <param name="factor">A scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(`0,System.Numerics.Vector{`0})">
-      <summary>Multiplies a vector by the given scalar.</summary>
-      <param name="factor">The scalar value.</param>
-      <param name="value">The source vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_OnesComplement(System.Numerics.Vector{`0})">
-      <summary>Returns a new vector whose elements are obtained by taking the one&amp;#39;s complement of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <returns>The one&amp;#39;s complement vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Subtraction(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_UnaryNegation(System.Numerics.Vector{`0})">
-      <summary>Negates a given vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of this vector using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString">
-      <summary>Returns the string representation of this vector using default formatting.</summary>
-      <returns>The string representation of this vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString(System.String)">
-      <summary>Returns the string representation of this vector using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Zero">
-      <summary>Returns a vector containing all zeroes.</summary>
-      <returns>A vector containing all zeroes.</returns>
-    </member>
-    <member name="T:System.Numerics.Vector">
-      <summary>Provides a collection of static convenience methods for creating, manipulating, combining, and converting generic vectors.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector.Abs``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the absolute values of the given vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Add``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the sum of each pair of elements from two given vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AndNot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise And Not operation on each pair of corresponding elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorByte``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned bytes.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorDouble``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a double-precision floating-point vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt16``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of 16-bit integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt32``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt64``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of long integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorSByte``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of signed bytes.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorSingle``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a single-precision floating-point vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt16``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned 16-bit integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt32``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt64``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned long integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.BitwiseAnd``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise And operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.BitwiseOr``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise Or operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Creates a new single-precision vector with elements selected between two specified single-precision source vectors based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Creates a new double-precision vector with elements selected between two specified double-precision source vectors based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Creates a new vector of a specified type with elements selected between two specified source vectors of the same type based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.Int64})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.UInt64})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToInt32(System.Numerics.Vector{System.Single})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToInt64(System.Numerics.Vector{System.Double})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.Int32})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.UInt32})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToUInt32(System.Numerics.Vector{System.Single})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToUInt64(System.Numerics.Vector{System.Double})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Divide``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the result of dividing the first vector&amp;#39;s elements by the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The divided vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Dot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified double-precision vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified integral vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new vector whose elements signal whether the elements in two specified long integer vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified single-precision vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector of a specified type whose elements signal whether the elements in two specified vectors of the same type are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.EqualsAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether each pair of elements in the given vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.EqualsAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any single pair of elements in the given vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element pair in <paramref name="left">left</paramref> and <paramref name="right">right</paramref> is equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are greater than their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are greater than their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are greater than their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision floating-point vector are greater than their corresponding elements in a second single-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector of a specified type are greater than their corresponding elements in the second vector of the same time.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are greater than the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> are greater than the corresponding elements in <paramref name="right">right</paramref>; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is greater than the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is greater than the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one vector are greater than or equal to their corresponding elements in the single-precision floating-point second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are greater than or equal to their corresponding elements in the second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are greater than or equal to their corresponding elements in the second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one vector are greater than or equal to their corresponding elements in the second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector of a specified type are greater than or equal to their corresponding elements in the second vector of the same type.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are greater than or equal to all the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> are greater than or equal to the corresponding elements in <paramref name="right">right</paramref>; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is greater than or equal to the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is greater than or equal to the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector.IsHardwareAccelerated">
-      <summary>Gets a value that indicates whether vector operations are subject to hardware acceleration through JIT intrinsic support.</summary>
-      <returns>true if vector operations are subject to hardware acceleration; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are less than their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are less than their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are less than their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision vector are less than their corresponding elements in a second single-precision vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector of a specified type whose elements signal whether the elements in one vector are less than their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all of the elements in the first vector are less than their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all of the elements in <paramref name="left">left</paramref> are less than the corresponding elements in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is less than the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is less than the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are less than or equal to their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are less than or equal to their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are less or equal to their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision floating-point vector are less than or equal to their corresponding elements in a second single-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector are less than or equal to their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are less than or equal to their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all of the elements in <paramref name="left">left</paramref> are less than or equal to the corresponding elements in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is less than or equal to the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is less than or equal to the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Max``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The maximum vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Min``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The minimum vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(``0,System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are a scalar value multiplied by each of the values of a specified vector.</summary>
-      <param name="left">The scalar value.</param>
-      <param name="right">The vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the product of each pair of elements in two specified vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},``0)">
-      <summary>Returns a new vector whose values are the values of a specified vector each multiplied by a scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int16})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt16})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt64})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Negate``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the negation of the corresponding element in the specified vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.OnesComplement``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are obtained by taking the one&amp;#39;s complement of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the square roots of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Subtract``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the difference between the elements in the second vector and their corresponding elements in the first vector.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32}@,System.Numerics.Vector{System.UInt32}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Double}@,System.Numerics.Vector{System.Double}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.Int16}@,System.Numerics.Vector{System.Int16}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt64}@,System.Numerics.Vector{System.UInt64}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int32}@,System.Numerics.Vector{System.Int32}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt16}@,System.Numerics.Vector{System.UInt16}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int64}@,System.Numerics.Vector{System.Int64}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Xor``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise exclusive Or (XOr) operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="T:System.Numerics.Vector2">
-      <summary>Represents a vector with two single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector2.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector2"></see> object whose two elements have the same value.</summary>
-      <param name="value">The value to assign to both elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector2.#ctor(System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector2.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector2.Y"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector2.Abs(System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Add(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Clamp(System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector2.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector2.Distance(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.DistanceSquared(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Dot(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Equals(System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Length">
-      <summary>Returns the length of the vector.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Lerp(System.Numerics.Vector2,System.Numerics.Vector2,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Max(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Min(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Single,System.Numerics.Vector2)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Negate(System.Numerics.Vector2)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Normalize(System.Numerics.Vector2)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="value">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.One">
-      <summary>Gets a vector whose 2 elements are equal to one.</summary>
-      <returns>A vector whose two elements are equal to one (that is, it returns the vector (1,1).</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Addition(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Equality(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Inequality(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Single,System.Numerics.Vector2)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Subtraction(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_UnaryNegation(System.Numerics.Vector2)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Reflect(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the reflection of a vector off a surface that has the specified normal.</summary>
-      <param name="vector">The source vector.</param>
-      <param name="normal">The normal of the surface being reflected off.</param>
-      <returns>The reflected vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.SquareRoot(System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Subtract(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
-      <summary>Transforms a vector by a specified 3x2 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
-      <summary>Transforms a vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
-      <summary>Transforms a vector normal by the given 3x2 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector normal by the given 4x4 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.UnitX">
-      <summary>Gets the vector (1,0).</summary>
-      <returns>The vector (1,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.UnitY">
-      <summary>Gets the vector (0,1).</summary>
-      <returns>The vector (0,1).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector2.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector2.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.Zero">
-      <summary>Returns a vector whose 2 elements are equal to zero.</summary>
-      <returns>A vector whose two elements are equal to zero (that is, it returns the vector (0,0).</returns>
-    </member>
-    <member name="T:System.Numerics.Vector3">
-      <summary>Represents a vector with three  single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector3"></see> object whose three elements have the same value.</summary>
-      <param name="value">The value to assign to all three elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Numerics.Vector2,System.Single)">
-      <summary>Creates a   new <see cref="T:System.Numerics.Vector3"></see> object from the specified <see cref="T:System.Numerics.Vector2"></see> object and the specified value.</summary>
-      <param name="value">The vector with two elements.</param>
-      <param name="z">The additional value to assign to the <see cref="F:System.Numerics.Vector3.Z"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Single,System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector3.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector3.Y"></see> field.</param>
-      <param name="z">The value to assign to the <see cref="F:System.Numerics.Vector3.Z"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.Abs(System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Add(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Clamp(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector3.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector3.Cross(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Computes the cross product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The cross product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Distance(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.DistanceSquared(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Dot(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Equals(System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Length">
-      <summary>Returns the length of this vector object.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Lerp(System.Numerics.Vector3,System.Numerics.Vector3,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Max(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Min(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Single,System.Numerics.Vector3)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Negate(System.Numerics.Vector3)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Normalize(System.Numerics.Vector3)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="value">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.One">
-      <summary>Gets a vector whose 3 elements are equal to one.</summary>
-      <returns>A vector whose three elements are equal to one (that is, it returns the vector (1,1,1).</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Addition(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Equality(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Inequality(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Single,System.Numerics.Vector3)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Subtraction(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_UnaryNegation(System.Numerics.Vector3)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Reflect(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the reflection of a vector off a surface that has the specified normal.</summary>
-      <param name="vector">The source vector.</param>
-      <param name="normal">The normal of the surface being reflected off.</param>
-      <returns>The reflected vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.SquareRoot(System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Subtract(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
-      <summary>Transforms a vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.TransformNormal(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector normal by the given 4x4 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitX">
-      <summary>Gets the vector (1,0,0).</summary>
-      <returns>The vector (1,0,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitY">
-      <summary>Gets the vector (0,1,0).</summary>
-      <returns>The vector (0,1,0)..</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitZ">
-      <summary>Gets the vector (0,0,1).</summary>
-      <returns>The vector (0,0,1).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.Z">
-      <summary>The Z component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.Zero">
-      <summary>Gets a vector whose 3 elements are equal to zero.</summary>
-      <returns>A vector whose three elements are equal to zero (that is, it returns the vector (0,0,0).</returns>
-    </member>
-    <member name="T:System.Numerics.Vector4">
-      <summary>Represents a vector with four single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector4"></see> object whose four elements have the same value.</summary>
-      <param name="value">The value to assign to all four elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Constructs a new <see cref="T:System.Numerics.Vector4"></see> object from the specified <see cref="T:System.Numerics.Vector3"></see> object and a W component.</summary>
-      <param name="value">The vector to use for the X, Y, and Z components.</param>
-      <param name="w">The W component.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector2,System.Single,System.Single)">
-      <summary>Creates a   new <see cref="T:System.Numerics.Vector4"></see> object from the specified <see cref="T:System.Numerics.Vector2"></see> object and a Z and a W component.</summary>
-      <param name="value">The vector to use for the X and Y components.</param>
-      <param name="z">The Z component.</param>
-      <param name="w">The W component.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector4.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector4.Y"></see> field.</param>
-      <param name="z">The value to assign to the <see cref="F:System.Numerics.Vector4.Z"></see> field.</param>
-      <param name="w">The value to assign to the <see cref="F:System.Numerics.Vector4.W"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.Abs(System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Add(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Clamp(System.Numerics.Vector4,System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector4.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector4.Distance(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.DistanceSquared(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Dot(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Equals(System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Length">
-      <summary>Returns the length of this vector object.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Lerp(System.Numerics.Vector4,System.Numerics.Vector4,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Max(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Min(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Single,System.Numerics.Vector4)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Negate(System.Numerics.Vector4)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Normalize(System.Numerics.Vector4)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="vector">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.One">
-      <summary>Gets a vector whose 4 elements are equal to one.</summary>
-      <returns>Returns <see cref="System.Numerics.Vector4"></see>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Addition(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Equality(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Inequality(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Single,System.Numerics.Vector4)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Subtraction(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_UnaryNegation(System.Numerics.Vector4)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.SquareRoot(System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Subtract(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Quaternion)">
-      <summary>Transforms a four-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Matrix4x4)">
-      <summary>Transforms a four-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="vector">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
-      <summary>Transforms a three-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a two-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
-      <summary>Transforms a two-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a three-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitW">
-      <summary>Gets the vector (0,0,0,1).</summary>
-      <returns>The vector (0,0,0,1).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitX">
-      <summary>Gets the vector (1,0,0,0).</summary>
-      <returns>The vector (1,0,0,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitY">
-      <summary>Gets the vector (0,1,0,0).</summary>
-      <returns>The vector (0,1,0,0)..</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitZ">
-      <summary>Gets a vector whose 4 elements are equal to zero.</summary>
-      <returns>The vector (0,0,1,0).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.W">
-      <summary>The W component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.Z">
-      <summary>The Z component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.Zero">
-      <summary>Gets a vector whose 4 elements are equal to zero.</summary>
-      <returns>A vector whose four elements are equal to zero (that is, it returns the vector (0,0,0,0).</returns>
-    </member>
-  </members>
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Numerics.Vectors</name>
+    </assembly>
+    <members>
+        <member name="T:System.Numerics.Matrix3x2">
+            <summary>
+            A structure encapsulating a 3x2 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M11">
+            <summary>
+            The first element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M12">
+            <summary>
+            The second element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M21">
+            <summary>
+            The first element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M22">
+            <summary>
+            The second element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M31">
+            <summary>
+            The first element of the third row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M32">
+            <summary>
+            The second element of the third row
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix3x2 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Numerics.Vector2)">
+            <summary>
+            Creates a translation matrix from the given vector.
+            </summary>
+            <param name="position">The translation position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix from the given X and Y components.
+            </summary>
+            <param name="xPosition">The X position.</param>
+            <param name="yPosition">The Y position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single)">
+            <summary>
+            Creates a scale matrix from the given X and Y components.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that is offset by a given center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale with an offset from the given center point.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale with an offset from the given center.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single)">
+            <summary>
+            Creates a skew matrix from the given angles in radians.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a skew matrix from the given angles in radians and a center point.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians and a center point.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetDeterminant">
+            <summary>
+            Calculates the determinant for this matrix. 
+            The determinant is calculated by expanding the matrix with a third column whose values are (0,0,1).
+            </summary>
+            <returns>The determinant.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Invert(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2@)">
+            <summary>
+            Attempts to invert the given matrix. If the operation succeeds, the inverted matrix is stored in the result parameter.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="result">The output matrix.</param>
+            <returns>True if the operation succeeded, False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Lerp(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Linearly interpolates from matrix1 to matrix2, based on the third parameter.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weighting of matrix2.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Negate(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Add(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Subtract(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_UnaryNegation(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Addition(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Subtraction(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Equality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Inequality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are not equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the matrix is equal to the other given matrix.
+            </summary>
+            <param name="other">The other matrix to test equality against.</param>
+            <returns>True if this matrix is equal to other; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Matrix4x4">
+            <summary>
+            A structure encapsulating a 4x4 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M11">
+            <summary>
+            Value at row 1, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M12">
+            <summary>
+            Value at row 1, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M13">
+            <summary>
+            Value at row 1, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M14">
+            <summary>
+            Value at row 1, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M21">
+            <summary>
+            Value at row 2, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M22">
+            <summary>
+            Value at row 2, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M23">
+            <summary>
+            Value at row 2, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M24">
+            <summary>
+            Value at row 2, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M31">
+            <summary>
+            Value at row 3, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M32">
+            <summary>
+            Value at row 3, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M33">
+            <summary>
+            Value at row 3, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M34">
+            <summary>
+            Value at row 3, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M41">
+            <summary>
+            Value at row 4, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M42">
+            <summary>
+            Value at row 4, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M43">
+            <summary>
+            Value at row 4, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M44">
+            <summary>
+            Value at row 4, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix4x4 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Numerics.Matrix3x2)">
+            <summary>
+            Constructs a Matrix4x4 from the given Matrix3x2.
+            </summary>
+            <param name="value">The source Matrix3x2.</param>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a spherical billboard that rotates around a specified object position.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="cameraUpVector">The up vector of the camera.</param>
+            <param name="cameraForwardVector">The forward vector of the camera.</param>
+            <returns>The created billboard matrix</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateConstrainedBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a cylindrical billboard that rotates around a specified axis.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="rotateAxis">Axis to rotate the billboard around.</param>
+            <param name="cameraForwardVector">Forward vector of the camera.</param>
+            <param name="objectForwardVector">Forward vector of the object.</param>
+            <returns>The created billboard matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Numerics.Vector3)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="position">The amount to translate in each axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="xPosition">The amount to translate on the X-axis.</param>
+            <param name="yPosition">The amount to translate on the Y-axis.</param>
+            <param name="zPosition">The amount to translate on the Z-axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis with a center point.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a matrix that rotates around an arbitrary vector.
+            </summary>
+            <param name="axis">The axis to rotate around.</param>
+            <param name="angle">The angle to rotate around the given axis, in radians.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances. 
+            </summary>
+            <param name="fieldOfView">Field of view in the y direction, in radians.</param>
+            <param name="aspectRatio">Aspect ratio, defined as view space width divided by height.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspective(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume at the near view plane.</param>
+            <param name="height">Height of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a customized, perspective projection matrix.
+            </summary>
+            <param name="left">Minimum x-value of the view volume at the near view plane.</param>
+            <param name="right">Maximum x-value of the view volume at the near view plane.</param>
+            <param name="bottom">Minimum y-value of the view volume at the near view plane.</param>
+            <param name="top">Maximum y-value of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to of the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographic(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates an orthographic perspective matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume.</param>
+            <param name="height">Height of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographicOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Builds a customized, orthographic projection matrix.
+            </summary>
+            <param name="left">Minimum X-value of the view volume.</param>
+            <param name="right">Maximum X-value of the view volume.</param>
+            <param name="bottom">Minimum Y-value of the view volume.</param>
+            <param name="top">Maximum Y-value of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateLookAt(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a view matrix.
+            </summary>
+            <param name="cameraPosition">The position of the camera.</param>
+            <param name="cameraTarget">The target towards which the camera is pointing.</param>
+            <param name="cameraUpVector">The direction that is "up" from the camera's point of view.</param>
+            <returns>The view matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateWorld(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a world matrix with the specified parameters.
+            </summary>
+            <param name="position">The position of the object; used in translation operations.</param>
+            <param name="forward">Forward direction of the object.</param>
+            <param name="up">Upward direction of the object; usually [0, 1, 0].</param>
+            <returns>The world matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromQuaternion(System.Numerics.Quaternion)">
+            <summary>
+            Creates a rotation matrix from the given Quaternion rotation value.
+            </summary>
+            <param name="quaternion">The source Quaternion.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a rotation matrix from the specified yaw, pitch, and roll.
+            </summary>
+            <param name="yaw">Angle of rotation, in radians, around the Y-axis.</param>
+            <param name="pitch">Angle of rotation, in radians, around the X-axis.</param>
+            <param name="roll">Angle of rotation, in radians, around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateShadow(System.Numerics.Vector3,System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that flattens geometry into a specified Plane as if casting a shadow from a specified light source.
+            </summary>
+            <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
+            <param name="plane">The Plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
+            <returns>A new Matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateReflection(System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that reflects the coordinate system about a specified Plane.
+            </summary>
+            <param name="value">The Plane about which to create a reflection.</param>
+            <returns>A new matrix expressing the reflection.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetDeterminant">
+            <summary>
+            Calculates the determinant of the matrix.
+            </summary>
+            <returns>The determinant of the matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Invert(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4@)">
+            <summary>
+            Attempts to calculate the inverse of the given matrix. If successful, result will contain the inverted matrix.
+            </summary>
+            <param name="matrix">The source matrix to invert.</param>
+            <param name="result">If successful, contains the inverted matrix.</param>
+            <returns>True if the source matrix could be inverted; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Decompose(System.Numerics.Matrix4x4,System.Numerics.Vector3@,System.Numerics.Quaternion@,System.Numerics.Vector3@)">
+            <summary>
+            Attempts to extract the scale, translation, and rotation components from the given scale/rotation/translation matrix.
+            If successful, the out parameters will contained the extracted values.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="scale">The scaling component of the transformation matrix.</param>
+            <param name="rotation">The rotation component of the transformation matrix.</param>
+            <param name="translation">The translation component of the transformation matrix</param>
+            <returns>True if the source matrix was successfully decomposed; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transform(System.Numerics.Matrix4x4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms the given matrix by applying the given Quaternion rotation.
+            </summary>
+            <param name="value">The source matrix to transform.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transpose(System.Numerics.Matrix4x4)">
+            <summary>
+            Transposes the rows and columns of a matrix.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <returns>The transposed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Linearly interpolates between the corresponding values of two matrices.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weight of the second source matrix.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Negate(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Add(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Subtract(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_UnaryNegation(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Addition(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Subtraction(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Equality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Inequality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are not equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
+            </summary>
+            <param name="other">The matrix to compare this instance to.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Plane">
+            <summary>
+            A structure encapsulating a 3D Plane
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.Normal">
+            <summary>
+            The normal vector of the Plane.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.D">
+            <summary>
+            The distance of the Plane along its normal from the origin.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Plane from the X, Y, and Z components of its normal, and its distance from the origin on that normal.
+            </summary>
+            <param name="x">The X-component of the normal.</param>
+            <param name="y">The Y-component of the normal.</param>
+            <param name="z">The Z-component of the normal.</param>
+            <param name="d">The distance of the Plane along its normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Plane from the given normal and distance along the normal from the origin.
+            </summary>
+            <param name="normal">The Plane's normal vector.</param>
+            <param name="d">The Plane's distance from the origin along its normal vector.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector4)">
+            <summary>
+            Constructs a Plane from the given Vector4.
+            </summary>
+            <param name="value">A vector whose first 3 elements describe the normal vector, 
+            and whose W component defines the distance along that normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.CreateFromVertices(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a Plane that contains the three given points.
+            </summary>
+            <param name="point1">The first point defining the Plane.</param>
+            <param name="point2">The second point defining the Plane.</param>
+            <param name="point3">The third point defining the Plane.</param>
+            <returns>The Plane containing the three points.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Normalize(System.Numerics.Plane)">
+            <summary>
+            Creates a new Plane whose normal vector is the source Plane's normal vector normalized.
+            </summary>
+            <param name="value">The source Plane.</param>
+            <returns>The normalized Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a normalized Plane by a Matrix.
+            </summary>
+            <param name="plane"> The normalized Plane to transform. 
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="matrix">The transformation matrix to apply to the Plane.</param>
+            <returns>The transformed Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Quaternion)">
+            <summary>
+             Transforms a normalized Plane by a Quaternion rotation.
+            </summary>
+            <param name="plane"> The normalized Plane to transform.
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="rotation">The Quaternion rotation to apply to the Plane.</param>
+            <returns>A new Plane that results from applying the rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Dot(System.Numerics.Plane,System.Numerics.Vector4)">
+            <summary>
+            Calculates the dot product of a Plane and Vector4.
+            </summary>
+            <param name="plane">The Plane.</param>
+            <param name="value">The Vector4.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotCoordinate(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the normal vector of this Plane plus the distance (D) value of the Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting value.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotNormal(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the Normal vector of this Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Equality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Inequality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are not equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the given Plane is equal to this Plane instance.
+            </summary>
+            <param name="other">The Plane to compare this instance to.</param>
+            <returns>True if the other Plane is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Plane instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Plane; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.ToString">
+            <summary>
+            Returns a String representing this Plane instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Quaternion">
+            <summary>
+            A structure encapsulating a four-dimensional vector (x,y,z,w), 
+            which is used to efficiently rotate an object about the (x,y,z) vector by the angle theta, where w = cos(theta/2).
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.X">
+            <summary>
+            Specifies the X-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Y">
+            <summary>
+            Specifies the Y-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Z">
+            <summary>
+            Specifies the Z-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.W">
+            <summary>
+            Specifies the rotation component of the Quaternion.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.Identity">
+            <summary>
+            Returns a Quaternion representing no rotation. 
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.IsIdentity">
+            <summary>
+            Returns whether the Quaternion is the identity Quaternion.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given components.
+            </summary>
+            <param name="x">The X component of the Quaternion.</param>
+            <param name="y">The Y component of the Quaternion.</param>
+            <param name="z">The Z component of the Quaternion.</param>
+            <param name="w">The W component of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given vector and rotation parts.
+            </summary>
+            <param name="vectorPart">The vector part of the Quaternion.</param>
+            <param name="scalarPart">The rotation part of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Length">
+            <summary>
+            Calculates the length of the Quaternion.
+            </summary>
+            <returns>The computed length of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.LengthSquared">
+            <summary>
+            Calculates the length squared of the Quaternion. This operation is cheaper than Length().
+            </summary>
+            <returns>The length squared of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Normalize(System.Numerics.Quaternion)">
+            <summary>
+            Divides each component of the Quaternion by the length of the Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The normalized Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Conjugate(System.Numerics.Quaternion)">
+            <summary>
+            Creates the conjugate of a specified Quaternion.
+            </summary>
+            <param name="value">The Quaternion of which to return the conjugate.</param>
+            <returns>A new Quaternion that is the conjugate of the specified one.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Inverse(System.Numerics.Quaternion)">
+            <summary>
+            Returns the inverse of a Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The inverted Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a Quaternion from a normalized vector axis and an angle to rotate about the vector.
+            </summary>
+            <param name="axis">The unit vector to rotate around.
+            This vector must be normalized before calling this function or the resulting Quaternion will be incorrect.</param>
+            <param name="angle">The angle, in radians, to rotate around the vector.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a new Quaternion from the given yaw, pitch, and roll, in radians.
+            </summary>
+            <param name="yaw">The yaw angle, in radians, around the Y-axis.</param>
+            <param name="pitch">The pitch angle, in radians, around the X-axis.</param>
+            <param name="roll">The roll angle, in radians, around the Z-axis.</param>
+            <returns></returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromRotationMatrix(System.Numerics.Matrix4x4)">
+            <summary>
+            Creates a Quaternion from the given rotation matrix.
+            </summary>
+            <param name="matrix">The rotation matrix.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Dot(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Calculates the dot product of two Quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <returns>The dot product of the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Slerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Interpolates between two quaternions, using spherical linear interpolation.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Lerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+             Linearly interpolates between two quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Concatenate(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Concatenates two Quaternions; the result represents the value1 rotation followed by the value2 rotation.
+            </summary>
+            <param name="value1">The first Quaternion rotation in the series.</param>
+            <param name="value2">The second Quaternion rotation in the series.</param>
+            <returns>A new Quaternion representing the concatenation of the value1 rotation followed by the value2 rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Negate(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Add(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Subtract(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Divide(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_UnaryNegation(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Addition(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Subtraction(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Division(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Equality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Inequality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are not equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the given Quaternion is equal to this Quaternion instance.
+            </summary>
+            <param name="other">The Quaternion to compare this instance to.</param>
+            <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Quaternion instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.ToString">
+            <summary>
+            Returns a String representing this Quaternion instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Register">
+            <summary>
+            A structure describing the layout of an SSE2-sized register.
+            Contains overlapping fields representing the set of valid numeric types.
+            Allows the generic Vector'T struct to contain an explicit field layout.
+            </summary>
+        </member>
+        <member name="T:System.Numerics.Vector`1">
+            <summary>
+            A structure that represents a single Vector. The count of this Vector is fixed but CPU register dependent.
+            This struct only supports numerical types. This type is intended to be used as a building block for vectorizing
+            large algorithms. This type is immutable, individual elements cannot be modified.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Count">
+            <summary>
+            Returns the number of elements stored in the vector. This value is hardware dependent.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Zero">
+            <summary>
+            Returns a vector containing all zeroes.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.One">
+            <summary>
+            Returns a vector containing all ones.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0)">
+            <summary>
+            Constructs a vector whose components are all <code>value</code>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[])">
+            <summary>
+            Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[],System.Int32)">
+            <summary>
+            Constructs a vector from the given array, starting from the given index.
+            The array must contain at least Vector'T.Count from the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[])">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[],System.Int32)">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <param name="startIndex">The index to start copying to</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Item(System.Int32)">
+            <summary>
+            Returns the element at the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this vector instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this vector; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether the given vector is equal to this vector instance.
+            </summary>
+            <param name="other">The vector to compare this instance to.</param>
+            <returns>True if the other vector is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString">
+            <summary>
+            Returns a String representing this vector.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Addition(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Subtraction(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},`0)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="value">The source vector.</param>
+            <param name="factor">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(`0,System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="factor">The scalar value.</param>
+            <param name="value">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Division(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_UnaryNegation(System.Numerics.Vector{`0})">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseAnd(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_ExclusiveOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_OnesComplement(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Equality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Inequality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if left and right are not equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Byte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.SByte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Single}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Double}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector">
+            <summary>
+            Contains various methods useful for creating, manipulating, combining, and converting generic vectors with one another.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt16}@,System.Numerics.Vector{System.UInt16}@)">
+            <summary>
+            Widens a Vector{Byte} into two Vector{UInt16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32}@,System.Numerics.Vector{System.UInt32}@)">
+            <summary>
+            Widens a Vector{UInt16} into two Vector{UInt32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt64}@,System.Numerics.Vector{System.UInt64}@)">
+            <summary>
+            Widens a Vector{UInt32} into two Vector{UInt64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.Int16}@,System.Numerics.Vector{System.Int16}@)">
+            <summary>
+            Widens a Vector{SByte} into two Vector{Int16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int32}@,System.Numerics.Vector{System.Int32}@)">
+            <summary>
+            Widens a Vector{Int16} into two Vector{Int32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int64}@,System.Numerics.Vector{System.Int64}@)">
+            <summary>
+            Widens a Vector{Int32} into two Vector{Int64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Double}@,System.Numerics.Vector{System.Double}@)">
+            <summary>
+            Widens a Vector{Single} into two Vector{Double}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt16})">
+            <summary>
+            Narrows two Vector{UInt16}'s into one Vector{Byte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Byte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Narrows two Vector{UInt32}'s into one Vector{UInt16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Narrows two Vector{UInt64}'s into one Vector{UInt32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int16})">
+            <summary>
+            Narrows two Vector{Int16}'s into one Vector{SByte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{SByte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Narrows two Vector{Int32}'s into one Vector{Int16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Narrows two Vector{Int64}'s into one Vector{Int32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Narrows two Vector{Double}'s into one Vector{Single}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Single} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.Int32})">
+            <summary>
+            Converts a Vector{Int32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Converts a Vector{UInt32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.Int64})">
+            <summary>
+            Converts a Vector{Int64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Converts a Vector{UInt64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{Int32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{UInt32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{Int64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{UInt64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any element pairs are equal; False if no element pairs are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are less than their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are less than or equal to their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are greater than the corresponding elements in right.
+            elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="P:System.Numerics.Vector.IsHardwareAccelerated">
+            <summary>
+            Returns whether or not vector operations are subject to hardware acceleration through JIT intrinsic support.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Abs``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the absolute values of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Min``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The minimum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Max``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The maximum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Dot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the square roots of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Add``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the sum of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Subtract``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the difference between each pairs of elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the product of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},``0)">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar factor.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(``0,System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The scalar factor.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Divide``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the result of dividing the first vector's elements 
+            by the corresponding elements in the second vector.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The divided vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Negate``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the given vector's elements negated.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseAnd``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseOr``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.OnesComplement``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Xor``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AndNot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and-not operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSingle``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 32-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorDouble``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 64-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector2">
+            <summary>
+            A structure encapsulating two single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.Zero">
+            <summary>
+            Returns the vector (0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.One">
+            <summary>
+            Returns the vector (1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitX">
+            <summary>
+            Returns the vector (1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitY">
+            <summary>
+            Returns the vector (0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector2 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector2; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString">
+            <summary>
+            Returns a String representing this Vector2 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Distance(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.DistanceSquared(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Normalize(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Reflect(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Clamp(System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.Lerp(System.Numerics.Vector2,System.Numerics.Vector2,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Add(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Subtract(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Negate(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector2.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector2.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+            <param name="array">The destination array.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from the given index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array
+            or if there are not enough elements to copy.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the given Vector2 is equal to this Vector2 instance.
+            </summary>
+            <param name="other">The Vector2 to compare this instance to.</param>
+            <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Dot(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="value1">The first vector.</param>
+            <param name="value2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Min(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Max(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors
+            </summary>
+            <param name="value1">The first source vector</param>
+            <param name="value2">The second source vector</param>
+            <returns>The maximized vector</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Abs(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>        
+        </member>
+        <member name="M:System.Numerics.Vector2.SquareRoot(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Addition(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Subtraction(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_UnaryNegation(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Equality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Inequality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector3">
+            <summary>
+            A structure encapsulating three single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.Zero">
+            <summary>
+            Returns the vector (0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.One">
+            <summary>
+            Returns the vector (1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitX">
+            <summary>
+            Returns the vector (1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitY">
+            <summary>
+            Returns the vector (0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitZ">
+            <summary>
+            Returns the vector (0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector3 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString">
+            <summary>
+            Returns a String representing this Vector3 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Distance(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.DistanceSquared(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Normalize(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Cross(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Computes the cross product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The cross product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Reflect(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Clamp(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Lerp(System.Numerics.Vector3,System.Numerics.Vector3,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.TransformNormal(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Add(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Subtract(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Negate(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector3.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Constructs a Vector3 from the given Vector2 and a third value.
+            </summary>
+            <param name="value">The Vector to extract X and Y components from.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the given Vector3 is equal to this Vector3 instance.
+            </summary>
+            <param name="other">The Vector3 to compare this instance to.</param>
+            <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Dot(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Min(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Max(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Abs(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.SquareRoot(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Addition(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Subtraction(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_UnaryNegation(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Equality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Inequality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector4">
+            <summary>
+            A structure encapsulating four single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.Zero">
+            <summary>
+            Returns the vector (0,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.One">
+            <summary>
+            Returns the vector (1,1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitX">
+            <summary>
+            Returns the vector (1,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitY">
+            <summary>
+            Returns the vector (0,1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitZ">
+            <summary>
+            Returns the vector (0,0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitW">
+            <summary>
+            Returns the vector (0,0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector4 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector4; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString">
+            <summary>
+            Returns a String representing this Vector4 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Length">
+            <summary>
+            Returns the length of the vector. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.LengthSquared">
+            <summary>
+            Returns the length of the vector squared.
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Distance(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.DistanceSquared(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Normalize(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="vector">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Clamp(System.Numerics.Vector4,System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Lerp(System.Numerics.Vector4,System.Numerics.Vector4,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Add(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Subtract(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Negate(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector4.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.W">
+            <summary>
+            The W component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="w">W component.</param>
+            <param name="x">X component.</param>
+            <param name="y">Y component.</param>
+            <param name="z">Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector2,System.Single,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector2 and a Z and W component.
+            </summary>
+            <param name="value">The vector to use as the X and Y components.</param>
+            <param name="z">The Z component.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector3 and a W component.
+            </summary>
+            <param name="value">The vector to use as the X, Y, and Z components.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the given Vector4 is equal to this Vector4 instance.
+            </summary>
+            <param name="other">The Vector4 to compare this instance to.</param>
+            <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Dot(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Min(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Max(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Abs(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.SquareRoot(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Addition(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Subtraction(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_UnaryNegation(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Equality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Inequality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="P:System.SR.Arg_ArgumentOutOfRangeException">
+            <summary>Index was out of bounds:</summary>
+        </member>
+        <member name="P:System.SR.Arg_ElementsInSourceIsGreaterThanDestination">
+            <summary>Number of elements in source vector is greater than the destination array</summary>
+        </member>
+        <member name="P:System.SR.Arg_NullArgumentNullRef">
+            <summary>The method was called with a null array argument.</summary>
+        </member>
+        <member name="P:System.SR.Arg_TypeNotSupported">
+            <summary>Specified type is not supported</summary>
+        </member>
+        <member name="P:System.SR.Arg_InsufficientNumberOfElements">
+            <summary>At least {0} element(s) are expected in the parameter "{1}".</summary>
+        </member>
+    </members>
 </doc>

--- a/Xv2CoreLib/bin/Release/System.Numerics.Vectors.xml
+++ b/Xv2CoreLib/bin/Release/System.Numerics.Vectors.xml
@@ -1,2621 +1,3451 @@
-﻿<?xml version="1.0" encoding="utf-8"?><doc>
-  <assembly>
-    <name>System.Numerics.Vectors</name>
-  </assembly>
-  <members>
-    <member name="T:System.Numerics.Matrix3x2">
-      <summary>Represents a 3x2 matrix.</summary>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a 3x2 matrix from the specified components.</summary>
-      <param name="m11">The value to assign to the first element in the first row.</param>
-      <param name="m12">The value to assign to the second element in the first row.</param>
-      <param name="m21">The value to assign to the first element in the second row.</param>
-      <param name="m22">The value to assign to the second element in the second row.</param>
-      <param name="m31">The value to assign to the first element in the third row.</param>
-      <param name="m32">The value to assign to the second element in the third row.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Add(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single)">
-      <summary>Creates a rotation matrix using the given rotation in radians.</summary>
-      <param name="radians">The amount of rotation, in radians.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single,System.Numerics.Vector2)">
-      <summary>Creates a rotation matrix using the specified rotation in radians and a center point.</summary>
-      <param name="radians">The amount of rotation, in radians.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single)">
-      <summary>Creates a scaling matrix from the specified X and Y components.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix that scales uniformly with the specified scale with an offset from the specified center.</summary>
-      <param name="scale">The uniform scale to use.</param>
-      <param name="centerPoint">The center offset.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix that is offset by a given center point.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single)">
-      <summary>Creates a scaling matrix that scales uniformly with the given scale.</summary>
-      <param name="scale">The uniform scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix from the specified vector scale.</summary>
-      <param name="scales">The scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Creates a scaling matrix from the specified vector scale with an offset from the specified center point.</summary>
-      <param name="scales">The scale to use.</param>
-      <param name="centerPoint">The center offset.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single)">
-      <summary>Creates a skew matrix from the specified angles in radians.</summary>
-      <param name="radiansX">The X angle, in radians.</param>
-      <param name="radiansY">The Y angle, in radians.</param>
-      <returns>The skew matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single,System.Numerics.Vector2)">
-      <summary>Creates a skew matrix from the specified angles in radians and a center point.</summary>
-      <param name="radiansX">The X angle, in radians.</param>
-      <param name="radiansY">The Y angle, in radians.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The skew matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Numerics.Vector2)">
-      <summary>Creates a translation matrix from the specified 2-dimensional vector.</summary>
-      <param name="position">The translation position.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Single,System.Single)">
-      <summary>Creates a translation matrix from the specified X and Y components.</summary>
-      <param name="xPosition">The X position.</param>
-      <param name="yPosition">The Y position.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Equals(System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether this instance and another 3x2 matrix are equal.</summary>
-      <param name="other">The other matrix.</param>
-      <returns>true if the two matrices are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.GetDeterminant">
-      <summary>Calculates the determinant for this matrix.</summary>
-      <returns>The determinant.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.Identity">
-      <summary>Gets the multiplicative identity matrix.</summary>
-      <returns>The multiplicative identify matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Invert(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2@)">
-      <summary>Inverts the specified matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The matrix to invert.</param>
-      <param name="result">When this method returns, contains the inverted matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was converted successfully; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.IsIdentity">
-      <summary>Indicates whether the current matrix is the identity matrix.</summary>
-      <returns>true if the current matrix is the identity matrix; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Lerp(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2,System.Single)">
-      <summary>Performs a linear interpolation from one matrix to a second matrix based on a value that specifies the weighting of the second matrix.</summary>
-      <param name="matrix1">The first matrix.</param>
-      <param name="matrix2">The second matrix.</param>
-      <param name="amount">The relative weighting of matrix2.</param>
-      <returns>The interpolated matrix.</returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M11">
-      <summary>The first element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M12">
-      <summary>The second element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M21">
-      <summary>The first element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M22">
-      <summary>The second element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M31">
-      <summary>The first element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix3x2.M32">
-      <summary>The second element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Negate(System.Numerics.Matrix3x2)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Addition(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Equality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether the specified matrices are equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Inequality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns a value that indicates whether the specified matrices are not equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_Subtraction(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.op_UnaryNegation(System.Numerics.Matrix3x2)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.Subtract(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix3x2.ToString">
-      <summary>Returns a string that represents this matrix.</summary>
-      <returns>The string representation of this matrix.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix3x2.Translation">
-      <summary>Gets or sets the translation component of this matrix.</summary>
-      <returns>The translation component of the current instance.</returns>
-    </member>
-    <member name="T:System.Numerics.Matrix4x4">
-      <summary>Represents a 4x4 matrix.</summary>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.#ctor(System.Numerics.Matrix3x2)">
-      <summary>Creates a <see cref="T:System.Numerics.Matrix4x4"></see> object from a specified <see cref="T:System.Numerics.Matrix3x2"></see> object.</summary>
-      <param name="value">A 3x2 matrix.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a 4x4 matrix from the specified components.</summary>
-      <param name="m11">The value to assign to the first element in the first row.</param>
-      <param name="m12">The value to assign to the second element in the first row.</param>
-      <param name="m13">The value to assign to the third element in the first row.</param>
-      <param name="m14">The value to assign to the fourth element in the first row.</param>
-      <param name="m21">The value to assign to the first element in the second row.</param>
-      <param name="m22">The value to assign to the second element in the second row.</param>
-      <param name="m23">The value to assign to the third element in the second row.</param>
-      <param name="m24">The value to assign to the third element in the second row.</param>
-      <param name="m31">The value to assign to the first element in the third row.</param>
-      <param name="m32">The value to assign to the second element in the third row.</param>
-      <param name="m33">The value to assign to the third element in the third row.</param>
-      <param name="m34">The value to assign to the fourth element in the third row.</param>
-      <param name="m41">The value to assign to the first element in the fourth row.</param>
-      <param name="m42">The value to assign to the second element in the fourth row.</param>
-      <param name="m43">The value to assign to the third element in the fourth row.</param>
-      <param name="m44">The value to assign to the fourth element in the fourth row.</param>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Add(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a spherical billboard that rotates around a specified object position.</summary>
-      <param name="objectPosition">The position of the object that the billboard will rotate around.</param>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="cameraUpVector">The up vector of the camera.</param>
-      <param name="cameraForwardVector">The forward vector of the camera.</param>
-      <returns>The created billboard.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateConstrainedBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a cylindrical billboard that rotates around a specified axis.</summary>
-      <param name="objectPosition">The position of the object that the billboard will rotate around.</param>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="rotateAxis">The axis to rotate the billboard around.</param>
-      <param name="cameraForwardVector">The forward vector of the camera.</param>
-      <param name="objectForwardVector">The forward vector of the object.</param>
-      <returns>The billboard matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a matrix that rotates around an arbitrary vector.</summary>
-      <param name="axis">The axis to rotate around.</param>
-      <param name="angle">The angle to rotate around axis, in radians.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromQuaternion(System.Numerics.Quaternion)">
-      <summary>Creates a rotation matrix from the specified Quaternion rotation value.</summary>
-      <param name="quaternion">The source Quaternion.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
-      <summary>Creates a rotation matrix from the specified yaw, pitch, and roll.</summary>
-      <param name="yaw">The angle of rotation, in radians, around the Y axis.</param>
-      <param name="pitch">The angle of rotation, in radians, around the X axis.</param>
-      <param name="roll">The angle of rotation, in radians, around the Z axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateLookAt(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a view matrix.</summary>
-      <param name="cameraPosition">The position of the camera.</param>
-      <param name="cameraTarget">The target towards which the camera is pointing.</param>
-      <param name="cameraUpVector">The direction that is &amp;quot;up&amp;quot; from the camera&amp;#39;s point of view.</param>
-      <returns>The view matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateOrthographic(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates an orthographic perspective matrix from the given view volume dimensions.</summary>
-      <param name="width">The width of the view volume.</param>
-      <param name="height">The height of the view volume.</param>
-      <param name="zNearPlane">The minimum Z-value of the view volume.</param>
-      <param name="zFarPlane">The maximum Z-value of the view volume.</param>
-      <returns>The orthographic projection matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateOrthographicOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a customized orthographic projection matrix.</summary>
-      <param name="left">The minimum X-value of the view volume.</param>
-      <param name="right">The maximum X-value of the view volume.</param>
-      <param name="bottom">The minimum Y-value of the view volume.</param>
-      <param name="top">The maximum Y-value of the view volume.</param>
-      <param name="zNearPlane">The minimum Z-value of the view volume.</param>
-      <param name="zFarPlane">The maximum Z-value of the view volume.</param>
-      <returns>The orthographic projection matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspective(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a perspective projection matrix from the given view volume dimensions.</summary>
-      <param name="width">The width of the view volume at the near view plane.</param>
-      <param name="height">The height of the view volume at the near view plane.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances.</summary>
-      <param name="fieldOfView">The field of view in the y direction, in radians.</param>
-      <param name="aspectRatio">The aspect ratio, defined as view space width divided by height.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fieldOfView">fieldOfView</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="fieldOfView">fieldOfView</paramref> is greater than or equal to <see cref="System.Math.PI"></see>.  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a customized perspective projection matrix.</summary>
-      <param name="left">The minimum x-value of the view volume at the near view plane.</param>
-      <param name="right">The maximum x-value of the view volume at the near view plane.</param>
-      <param name="bottom">The minimum y-value of the view volume at the near view plane.</param>
-      <param name="top">The maximum y-value of the view volume at the near view plane.</param>
-      <param name="nearPlaneDistance">The distance to the near view plane.</param>
-      <param name="farPlaneDistance">The distance to the far view plane.</param>
-      <returns>The perspective projection matrix.</returns>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="farPlaneDistance">farPlaneDistance</paramref> is less than or equal to zero.  
- -or-  
- <paramref name="nearPlaneDistance">nearPlaneDistance</paramref> is greater than or equal to <paramref name="farPlaneDistance">farPlaneDistance</paramref>.</exception>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateReflection(System.Numerics.Plane)">
-      <summary>Creates a matrix that reflects the coordinate system about a specified plane.</summary>
-      <param name="value">The plane about which to create a reflection.</param>
-      <returns>A new matrix expressing the reflection.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single)">
-      <summary>Creates a matrix for rotating points around the X axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the X axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a matrix for rotating points around the X axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the X axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single,System.Numerics.Vector3)">
-      <summary>The amount, in radians, by which to rotate around the Y axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single)">
-      <summary>Creates a matrix for rotating points around the Y axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single)">
-      <summary>Creates a matrix for rotating points around the Z axis.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a matrix for rotating points around the Z axis from a center point.</summary>
-      <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The rotation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix from the specified vector scale.</summary>
-      <param name="scales">The scale to use.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single)">
-      <summary>Creates a uniform scaling matrix that scale equally on each axis.</summary>
-      <param name="scale">The uniform scaling factor.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix with a center point.</summary>
-      <param name="scales">The vector that contains the amount to scale on each axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Numerics.Vector3)">
-      <summary>Creates a uniform scaling matrix that scales equally on each axis with a center point.</summary>
-      <param name="scale">The uniform scaling factor.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single)">
-      <summary>Creates a scaling matrix from the specified X, Y, and Z components.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="zScale">The value to scale by on the Z axis.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single,System.Numerics.Vector3)">
-      <summary>Creates a scaling matrix that is offset by a given center point.</summary>
-      <param name="xScale">The value to scale by on the X axis.</param>
-      <param name="yScale">The value to scale by on the Y axis.</param>
-      <param name="zScale">The value to scale by on the Z axis.</param>
-      <param name="centerPoint">The center point.</param>
-      <returns>The scaling matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateShadow(System.Numerics.Vector3,System.Numerics.Plane)">
-      <summary>Creates a matrix that flattens geometry into a specified plane as if casting a shadow from a specified light source.</summary>
-      <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
-      <param name="plane">The plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
-      <returns>A new matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Numerics.Vector3)">
-      <summary>Creates a translation matrix from the specified 3-dimensional vector.</summary>
-      <param name="position">The amount to translate in each axis.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Single,System.Single,System.Single)">
-      <summary>Creates a translation matrix from the specified X, Y, and Z components.</summary>
-      <param name="xPosition">The amount to translate on the X axis.</param>
-      <param name="yPosition">The amount to translate on the Y axis.</param>
-      <param name="zPosition">The amount to translate on the Z axis.</param>
-      <returns>The translation matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.CreateWorld(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a world matrix with the specified parameters.</summary>
-      <param name="position">The position of the object.</param>
-      <param name="forward">The forward direction of the object.</param>
-      <param name="up">The upward direction of the object. Its value is usually [0, 1, 0].</param>
-      <returns>The world matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Decompose(System.Numerics.Matrix4x4,System.Numerics.Vector3@,System.Numerics.Quaternion@,System.Numerics.Vector3@)">
-      <summary>Attempts to extract the scale, translation, and rotation components from the given scale, rotation, or translation matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The source matrix.</param>
-      <param name="scale">When this method returns, contains the scaling component of the transformation matrix if the operation succeeded.</param>
-      <param name="rotation">When this method returns, contains the rotation component of the transformation matrix if the operation succeeded.</param>
-      <param name="translation">When the method returns, contains the translation component of the transformation matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was decomposed successfully; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Equals(System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether this instance and another 4x4 matrix are equal.</summary>
-      <param name="other">The other matrix.</param>
-      <returns>true if the two matrices are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.GetDeterminant">
-      <summary>Calculates the determinant of the current 4x4 matrix.</summary>
-      <returns>The determinant.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.Identity">
-      <summary>Gets the multiplicative identity matrix.</summary>
-      <returns>Gets the multiplicative identity matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Invert(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4@)">
-      <summary>Inverts the specified matrix. The return value indicates whether the operation succeeded.</summary>
-      <param name="matrix">The matrix to invert.</param>
-      <param name="result">When this method returns, contains the inverted matrix if the operation succeeded.</param>
-      <returns>true if <paramref name="matrix">matrix</paramref> was converted successfully; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.IsIdentity">
-      <summary>Indicates whether the current matrix is the identity matrix.</summary>
-      <returns>true if the current matrix is the identity matrix; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,System.Single)">
-      <summary>Performs a linear interpolation from one matrix to a second matrix based on a value that specifies the weighting of the second matrix.</summary>
-      <param name="matrix1">The first matrix.</param>
-      <param name="matrix2">The second matrix.</param>
-      <param name="amount">The relative weighting of matrix2.</param>
-      <returns>The interpolated matrix.</returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M11">
-      <summary>The first element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M12">
-      <summary>The second element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M13">
-      <summary>The third element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M14">
-      <summary>The fourth element of the first row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M21">
-      <summary>The first element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M22">
-      <summary>The second element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M23">
-      <summary>The third element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M24">
-      <summary>The fourth element of the second row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M31">
-      <summary>The first element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M32">
-      <summary>The second element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M33">
-      <summary>The third element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M34">
-      <summary>The fourth element of the third row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M41">
-      <summary>The first element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M42">
-      <summary>The second element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M43">
-      <summary>The third element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Matrix4x4.M44">
-      <summary>The fourth element of the fourth row.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Negate(System.Numerics.Matrix4x4)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Addition(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Adds each element in one matrix with its corresponding element in a second matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix that contains the summed values.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Equality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether the specified matrices are equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to care</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Inequality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns a value that indicates whether the specified matrices are not equal.</summary>
-      <param name="value1">The first matrix to compare.</param>
-      <param name="value2">The second matrix to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Single)">
-      <summary>Returns the matrix that results from scaling all the elements of a specified matrix by a scalar factor.</summary>
-      <param name="value1">The matrix to scale.</param>
-      <param name="value2">The scaling value to use.</param>
-      <returns>The scaled matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Returns the matrix that results from multiplying two matrices together.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The product matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_Subtraction(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.op_UnaryNegation(System.Numerics.Matrix4x4)">
-      <summary>Negates the specified matrix by multiplying all its values by -1.</summary>
-      <param name="value">The matrix to negate.</param>
-      <returns>The negated matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Subtract(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
-      <summary>Subtracts each element in a second matrix from its corresponding element in a first matrix.</summary>
-      <param name="value1">The first matrix.</param>
-      <param name="value2">The second matrix.</param>
-      <returns>The matrix containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.ToString">
-      <summary>Returns a string that represents this matrix.</summary>
-      <returns>The string representation of this matrix.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Transform(System.Numerics.Matrix4x4,System.Numerics.Quaternion)">
-      <summary>Transforms the specified matrix by applying the specified Quaternion rotation.</summary>
-      <param name="value">The matrix to transform.</param>
-      <param name="rotation">The rotation t apply.</param>
-      <returns>The transformed matrix.</returns>
-    </member>
-    <member name="P:System.Numerics.Matrix4x4.Translation">
-      <summary>Gets or sets the translation component of this matrix.</summary>
-      <returns>The translation component of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Matrix4x4.Transpose(System.Numerics.Matrix4x4)">
-      <summary>Transposes the rows and columns of a matrix.</summary>
-      <param name="matrix">The matrix to transpose.</param>
-      <returns>The transposed matrix.</returns>
-    </member>
-    <member name="T:System.Numerics.Plane">
-      <summary>Represents a three-dimensional plane.</summary>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector4)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from a specified four-dimensional vector.</summary>
-      <param name="value">A vector whose first three elements describe the normal vector, and whose <see cref="F:System.Numerics.Vector4.W"></see> defines the distance along that normal from the origin.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from a specified normal and the distance along the normal from the origin.</summary>
-      <param name="normal">The plane&amp;#39;s normal vector.</param>
-      <param name="d">The plane&amp;#39;s distance from the origin along its normal vector.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object from the X, Y, and Z components of its normal, and its distance from the origin on that normal.</summary>
-      <param name="x">The X component of the normal.</param>
-      <param name="y">The Y component of the normal.</param>
-      <param name="z">The Z component of the normal.</param>
-      <param name="d">The distance of the plane along its normal from the origin.</param>
-    </member>
-    <member name="M:System.Numerics.Plane.CreateFromVertices(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Creates a <see cref="T:System.Numerics.Plane"></see> object that contains three specified points.</summary>
-      <param name="point1">The first point defining the plane.</param>
-      <param name="point2">The second point defining the plane.</param>
-      <param name="point3">The third point defining the plane.</param>
-      <returns>The plane containing the three points.</returns>
-    </member>
-    <member name="F:System.Numerics.Plane.D">
-      <summary>The distance of the plane along its normal from the origin.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Dot(System.Numerics.Plane,System.Numerics.Vector4)">
-      <summary>Calculates the dot product of a plane and a 4-dimensional vector.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The four-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.DotCoordinate(System.Numerics.Plane,System.Numerics.Vector3)">
-      <summary>Returns the dot product of a specified three-dimensional vector and the normal vector of this plane plus the distance (<see cref="F:System.Numerics.Plane.D"></see>) value of the plane.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The 3-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.DotNormal(System.Numerics.Plane,System.Numerics.Vector3)">
-      <summary>Returns the dot product of a specified three-dimensional vector and the <see cref="F:System.Numerics.Plane.Normal"></see> vector of this plane.</summary>
-      <param name="plane">The plane.</param>
-      <param name="value">The three-dimensional vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Equals(System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether this instance and another plane object are equal.</summary>
-      <param name="other">The other plane.</param>
-      <returns>true if the two planes are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="F:System.Numerics.Plane.Normal">
-      <summary>The normal vector of the plane.</summary>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Normalize(System.Numerics.Plane)">
-      <summary>Creates a new <see cref="T:System.Numerics.Plane"></see> object whose normal vector is the source plane&amp;#39;s normal vector normalized.</summary>
-      <param name="value">The source plane.</param>
-      <returns>The normalized plane.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.op_Equality(System.Numerics.Plane,System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether two planes are equal.</summary>
-      <param name="value1">The first plane to compare.</param>
-      <param name="value2">The second plane to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.op_Inequality(System.Numerics.Plane,System.Numerics.Plane)">
-      <summary>Returns a value that indicates whether two planes are not equal.</summary>
-      <param name="value1">The first plane to compare.</param>
-      <param name="value2">The second plane to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.ToString">
-      <summary>Returns the string representation of this plane object.</summary>
-      <returns>A string that represents this <see cref="System.Numerics.Plane"></see> object.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Matrix4x4)">
-      <summary>Transforms a normalized plane by a 4x4 matrix.</summary>
-      <param name="plane">The normalized plane to transform.</param>
-      <param name="matrix">The transformation matrix to apply to plane.</param>
-      <returns>The transformed plane.</returns>
-    </member>
-    <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Quaternion)">
-      <summary>Transforms a normalized plane by a Quaternion rotation.</summary>
-      <param name="plane">The normalized plane to transform.</param>
-      <param name="rotation">The Quaternion rotation to apply to the plane.</param>
-      <returns>A new plane that results from applying the Quaternion rotation.</returns>
-    </member>
-    <member name="T:System.Numerics.Quaternion">
-      <summary>Represents a vector that is used to encode three-dimensional physical rotations.</summary>
-    </member>
-    <member name="M:System.Numerics.Quaternion.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a quaternion from the specified vector and rotation parts.</summary>
-      <param name="vectorPart">The vector part of the quaternion.</param>
-      <param name="scalarPart">The rotation part of the quaternion.</param>
-    </member>
-    <member name="M:System.Numerics.Quaternion.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Constructs a quaternion from the specified components.</summary>
-      <param name="x">The value to assign to the X component of the quaternion.</param>
-      <param name="y">The value to assign to the Y component of the quaternion.</param>
-      <param name="z">The value to assign to the Z component of the quaternion.</param>
-      <param name="w">The value to assign to the W component of the quaternion.</param>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Add(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Adds each element in one quaternion with its corresponding element in a second quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Concatenate(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Concatenates two quaternions.</summary>
-      <param name="value1">The first quaternion rotation in the series.</param>
-      <param name="value2">The second quaternion rotation in the series.</param>
-      <returns>A new quaternion representing the concatenation of the <paramref name="value1">value1</paramref> rotation followed by the <paramref name="value2">value2</paramref> rotation.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Conjugate(System.Numerics.Quaternion)">
-      <summary>Returns the conjugate of a specified quaternion.</summary>
-      <param name="value">The quaternion.</param>
-      <returns>A new quaternion that is the conjugate of value.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
-      <summary>Creates a quaternion from a vector and an angle to rotate about the vector.</summary>
-      <param name="axis">The vector to rotate around.</param>
-      <param name="angle">The angle, in radians, to rotate around the vector.</param>
-      <returns>The newly created quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromRotationMatrix(System.Numerics.Matrix4x4)">
-      <summary>Creates a quaternion from the specified rotation matrix.</summary>
-      <param name="matrix">The rotation matrix.</param>
-      <returns>The newly created quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
-      <summary>Creates a new quaternion from the given yaw, pitch, and roll.</summary>
-      <param name="yaw">The yaw angle, in radians, around the Y axis.</param>
-      <param name="pitch">The pitch angle, in radians, around the X axis.</param>
-      <param name="roll">The roll angle, in radians, around the Z axis.</param>
-      <returns>The resulting quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Divide(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Divides one quaternion by a second quaternion.</summary>
-      <param name="value1">The dividend.</param>
-      <param name="value2">The divisor.</param>
-      <returns>The quaternion that results from dividing <paramref name="value1">value1</paramref> by <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Dot(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Calculates the dot product of two quaternions.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Equals(System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether this instance and another quaternion are equal.</summary>
-      <param name="other">The other quaternion.</param>
-      <returns>true if the two quaternions are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Quaternion.Identity">
-      <summary>Gets a quaternion that represents no rotation.</summary>
-      <returns>A quaternion whose values are (0, 0, 0, 1).</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Inverse(System.Numerics.Quaternion)">
-      <summary>Returns the inverse of a quaternion.</summary>
-      <param name="value">The quaternion.</param>
-      <returns>The inverted quaternion.</returns>
-    </member>
-    <member name="P:System.Numerics.Quaternion.IsIdentity">
-      <summary>Gets a value that indicates whether the current instance is the identity quaternion.</summary>
-      <returns>true if the current instance is the identity quaternion; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Length">
-      <summary>Calculates the length of the quaternion.</summary>
-      <returns>The computed length of the quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.LengthSquared">
-      <summary>Calculates the squared length of the quaternion.</summary>
-      <returns>The length squared of the quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Lerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
-      <summary>Performs a linear interpolation between two quaternions based on a value that specifies the weighting of the second quaternion.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <param name="amount">The relative weight of quaternion2 in the interpolation.</param>
-      <returns>The interpolated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns the quaternion that results from multiplying two quaternions together.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The product quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Single)">
-      <summary>Returns the quaternion that results from scaling all the components of a specified quaternion by a scalar factor.</summary>
-      <param name="value1">The source quaternion.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The scaled quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Negate(System.Numerics.Quaternion)">
-      <summary>Reverses the sign of each component of the quaternion.</summary>
-      <param name="value">The quaternion to negate.</param>
-      <returns>The negated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Normalize(System.Numerics.Quaternion)">
-      <summary>Divides each component of a specified <see cref="T:System.Numerics.Quaternion"></see> by its length.</summary>
-      <param name="value">The quaternion to normalize.</param>
-      <returns>The normalized quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Addition(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Adds each element in one quaternion with its corresponding element in a second quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion that contains the summed values of <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Division(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Divides one quaternion by a second quaternion.</summary>
-      <param name="value1">The dividend.</param>
-      <param name="value2">The divisor.</param>
-      <returns>The quaternion that results from dividing <paramref name="value1">value1</paramref> by <paramref name="value2">value2</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Equality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether two quaternions are equal.</summary>
-      <param name="value1">The first quaternion to compare.</param>
-      <param name="value2">The second quaternion to compare.</param>
-      <returns>true if the two quaternions are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Inequality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns a value that indicates whether two quaternions are not equal.</summary>
-      <param name="value1">The first quaternion to compare.</param>
-      <param name="value2">The second quaternion to compare.</param>
-      <returns>true if <paramref name="value1">value1</paramref> and <paramref name="value2">value2</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Single)">
-      <summary>Returns the quaternion that results from scaling all the components of a specified quaternion by a scalar factor.</summary>
-      <param name="value1">The source quaternion.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The scaled quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Returns the quaternion that results from multiplying two quaternions together.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The product quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_Subtraction(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Subtracts each element in a second quaternion from its corresponding element in a first quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.op_UnaryNegation(System.Numerics.Quaternion)">
-      <summary>Reverses the sign of each component of the quaternion.</summary>
-      <param name="value">The quaternion to negate.</param>
-      <returns>The negated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Slerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
-      <summary>Interpolates between two quaternions, using spherical linear interpolation.</summary>
-      <param name="quaternion1">The first quaternion.</param>
-      <param name="quaternion2">The second quaternion.</param>
-      <param name="amount">The relative weight of the second quaternion in the interpolation.</param>
-      <returns>The interpolated quaternion.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.Subtract(System.Numerics.Quaternion,System.Numerics.Quaternion)">
-      <summary>Subtracts each element in a second quaternion from its corresponding element in a first quaternion.</summary>
-      <param name="value1">The first quaternion.</param>
-      <param name="value2">The second quaternion.</param>
-      <returns>The quaternion containing the values that result from subtracting each element in <paramref name="value2">value2</paramref> from its corresponding element in <paramref name="value1">value1</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Quaternion.ToString">
-      <summary>Returns a string that represents this quaternion.</summary>
-      <returns>The string representation of this quaternion.</returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.W">
-      <summary>The rotation component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.X">
-      <summary>The X value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.Y">
-      <summary>The Y value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Quaternion.Z">
-      <summary>The Z value of the vector component of the quaternion.</summary>
-      <returns></returns>
-    </member>
-    <member name="T:System.Numerics.Vector`1">
-      <summary>Represents a single vector of a specified numeric type that is suitable for low-level optimization of parallel algorithms.</summary>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0)">
-      <summary>Creates a vector whose components are of a specified type.</summary>
-      <param name="value">The numeric type that defines the type of the components in the vector.</param>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0[])">
-      <summary>Creates a vector from a specified array.</summary>
-      <param name="values">A numeric array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="values">values</paramref> is null.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.#ctor(`0[],System.Int32)">
-      <summary>Creates a vector from a specified array starting at a specified index position.</summary>
-      <param name="values">A numeric array.</param>
-      <param name="index">The starting index position from which to create the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="values">values</paramref> is null.</exception>
-      <exception cref="T:System.IndexOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- The length of <paramref name="values">values</paramref> minus <paramref name="index">index</paramref> is less than <see cref="System.Numerics.Vector`1.Count"></see>.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.CopyTo(`0[])">
-      <summary>Copies the vector instance to a specified destination array.</summary>
-      <param name="destination">The array to receive a copy of the vector values.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="destination">destination</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current vector is greater than the number of elements available in the <paramref name="destination">destination</paramref> array.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.CopyTo(`0[],System.Int32)">
-      <summary>Copies the vector instance to a specified destination array starting at a specified index position.</summary>
-      <param name="destination">The array to receive a copy of the vector values.</param>
-      <param name="startIndex">The starting index in destination at which to begin the copy operation.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="destination">destination</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than the number of elements available from <paramref name="startIndex">startIndex</paramref> to the end of the <paramref name="destination">destination</paramref> array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero or greater than the last index in <paramref name="destination">destination</paramref>.</exception>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Count">
-      <summary>Returns the number of elements stored in the vector.</summary>
-      <returns>The number of elements stored in the vector.</returns>
-      <exception cref="T:System.NotSupportedException">Access to the property getter via reflection is not supported.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector`1.Equals(System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether this instance is equal to a specified vector.</summary>
-      <param name="other">The vector to compare with this instance.</param>
-      <returns>true if the current instance and <paramref name="other">other</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance is equal to a specified object.</summary>
-      <param name="obj">The object to compare with this instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. The method returns false if <paramref name="obj">obj</paramref> is null, or if <paramref name="obj">obj</paramref> is a vector of a different type than the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Item(System.Int32)">
-      <summary>Gets the element at a specified index.</summary>
-      <param name="index">The index of the element to return.</param>
-      <returns>The element at index <paramref name="index">index</paramref>.</returns>
-      <exception cref="T:System.IndexOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to <see cref="System.Numerics.Vector`1.Count"></see>.</exception>
-    </member>
-    <member name="P:System.Numerics.Vector`1.One">
-      <summary>Returns a vector containing all ones.</summary>
-      <returns>A vector containing all ones.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Addition(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_BitwiseAnd(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise And operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise And of <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_BitwiseOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise Or operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise Or of the elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Division(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Equality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_ExclusiveOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a new vector by performing a bitwise XOr operation on each of the elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from the bitwise XOr of the elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt64}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt64"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt32}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt32"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.UInt16}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.UInt16"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Single}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Single"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.SByte}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.SByte"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Double}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Double"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int32}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int32"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int16}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int16"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Byte}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Byte"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{T})~System.Numerics.Vector{System.Int64}">
-      <summary>Reinterprets the bits of the specified vector into a vector of type <see cref="T:System.Int64"></see>.</summary>
-      <param name="value">The vector to reinterpret.</param>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Inequality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Returns a value that indicates whether any single pair of elements in the specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if any element pairs in left and right are equal. false if no element pairs are equal.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},`0)">
-      <summary>Multiplies a vector by a specified scalar value.</summary>
-      <param name="value">The source vector.</param>
-      <param name="factor">A scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Multiply(`0,System.Numerics.Vector{`0})">
-      <summary>Multiplies a vector by the given scalar.</summary>
-      <param name="factor">The scalar value.</param>
-      <param name="value">The source vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_OnesComplement(System.Numerics.Vector{`0})">
-      <summary>Returns a new vector whose elements are obtained by taking the one&amp;#39;s complement of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <returns>The one&amp;#39;s complement vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_Subtraction(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.op_UnaryNegation(System.Numerics.Vector{`0})">
-      <summary>Negates a given vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of this vector using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString">
-      <summary>Returns the string representation of this vector using default formatting.</summary>
-      <returns>The string representation of this vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector`1.ToString(System.String)">
-      <summary>Returns the string representation of this vector using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector`1.Zero">
-      <summary>Returns a vector containing all zeroes.</summary>
-      <returns>A vector containing all zeroes.</returns>
-    </member>
-    <member name="T:System.Numerics.Vector">
-      <summary>Provides a collection of static convenience methods for creating, manipulating, combining, and converting generic vectors.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector.Abs``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the absolute values of the given vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Add``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the sum of each pair of elements from two given vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AndNot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise And Not operation on each pair of corresponding elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorByte``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned bytes.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorDouble``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a double-precision floating-point vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt16``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of 16-bit integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt32``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorInt64``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of long integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorSByte``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of signed bytes.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorSingle``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a single-precision floating-point vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt16``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned 16-bit integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt32``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.AsVectorUInt64``1(System.Numerics.Vector{``0})">
-      <summary>Reinterprets the bits of a specified vector into those of a vector of unsigned long integers.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The reinterpreted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.BitwiseAnd``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise And operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.BitwiseOr``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise Or operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Creates a new single-precision vector with elements selected between two specified single-precision source vectors based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Creates a new double-precision vector with elements selected between two specified double-precision source vectors based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConditionalSelect``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Creates a new vector of a specified type with elements selected between two specified source vectors of the same type based on an integral mask vector.</summary>
-      <param name="condition">The integral mask vector used to drive selection.</param>
-      <param name="left">The first source vector.</param>
-      <param name="right">The second source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The new vector with elements selected based on the mask.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.Int64})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.UInt64})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToInt32(System.Numerics.Vector{System.Single})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToInt64(System.Numerics.Vector{System.Double})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.Int32})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.UInt32})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToUInt32(System.Numerics.Vector{System.Single})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.ConvertToUInt64(System.Numerics.Vector{System.Double})">
-      <param name="value"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Divide``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the result of dividing the first vector&amp;#39;s elements by the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The divided vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Dot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified double-precision vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified integral vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new vector whose elements signal whether the elements in two specified long integer vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in two specified single-precision vectors are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Equals``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector of a specified type whose elements signal whether the elements in two specified vectors of the same type are equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.EqualsAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether each pair of elements in the given vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.EqualsAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any single pair of elements in the given vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element pair in <paramref name="left">left</paramref> and <paramref name="right">right</paramref> is equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are greater than their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are greater than their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are greater than their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision floating-point vector are greater than their corresponding elements in a second single-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector of a specified type are greater than their corresponding elements in the second vector of the same time.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are greater than the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> are greater than the corresponding elements in <paramref name="right">right</paramref>; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is greater than the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is greater than the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one vector are greater than or equal to their corresponding elements in the single-precision floating-point second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are greater than or equal to their corresponding elements in the second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are greater than or equal to their corresponding elements in the second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one vector are greater than or equal to their corresponding elements in the second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector of a specified type are greater than or equal to their corresponding elements in the second vector of the same type.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are greater than or equal to all the corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all elements in <paramref name="left">left</paramref> are greater than or equal to the corresponding elements in <paramref name="right">right</paramref>; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.GreaterThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is greater than or equal to the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is greater than or equal to the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector.IsHardwareAccelerated">
-      <summary>Gets a value that indicates whether vector operations are subject to hardware acceleration through JIT intrinsic support.</summary>
-      <returns>true if vector operations are subject to hardware acceleration; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are less than their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are less than their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are less than their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision vector are less than their corresponding elements in a second single-precision vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector of a specified type whose elements signal whether the elements in one vector are less than their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all of the elements in the first vector are less than their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all of the elements in <paramref name="left">left</paramref> are less than the corresponding elements in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is less than the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is less than the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one double-precision floating-point vector are less than or equal to their corresponding elements in a second double-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one integral vector are less than or equal to their corresponding elements in a second integral vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <summary>Returns a new long integer vector whose elements signal whether the elements in one long integer vector are less or equal to their corresponding elements in a second long integer vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting long integer vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
-      <summary>Returns a new integral vector whose elements signal whether the elements in one single-precision floating-point vector are less than or equal to their corresponding elements in a second single-precision floating-point vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>The resulting integral vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements signal whether the elements in one vector are less than or equal to their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether all elements in the first vector are less than or equal to their corresponding elements in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if all of the elements in <paramref name="left">left</paramref> are less than or equal to the corresponding elements in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.LessThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a value that indicates whether any element in the first vector is less than or equal to the corresponding element in the second vector.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>true if any element in <paramref name="left">left</paramref> is less than or equal to the corresponding element in <paramref name="right">right</paramref>; otherwise,  false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Max``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The maximum vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Min``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The minimum vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(``0,System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are a scalar value multiplied by each of the values of a specified vector.</summary>
-      <param name="left">The scalar value.</param>
-      <param name="right">The vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the product of each pair of elements in two specified vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},``0)">
-      <summary>Returns a new vector whose values are the values of a specified vector each multiplied by a scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int16})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt16})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt64})">
-      <param name="source1"></param>
-      <param name="source2"></param>
-      <returns></returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Negate``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the negation of the corresponding element in the specified vector.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.OnesComplement``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are obtained by taking the one&amp;#39;s complement of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose elements are the square roots of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">The source vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Subtract``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector whose values are the difference between the elements in the second vector and their corresponding elements in the first vector.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32}@,System.Numerics.Vector{System.UInt32}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Double}@,System.Numerics.Vector{System.Double}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.Int16}@,System.Numerics.Vector{System.Int16}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt64}@,System.Numerics.Vector{System.UInt64}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int32}@,System.Numerics.Vector{System.Int32}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt16}@,System.Numerics.Vector{System.UInt16}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int64}@,System.Numerics.Vector{System.Int64}@)">
-      <param name="source"></param>
-      <param name="dest1"></param>
-      <param name="dest2"></param>
-    </member>
-    <member name="M:System.Numerics.Vector.Xor``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
-      <summary>Returns a new vector by performing a bitwise exclusive Or (XOr) operation on each pair of elements in two vectors.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <typeparam name="T">The vector type. T can be any primitive numeric type.</typeparam>
-      <returns>The resulting vector.</returns>
-    </member>
-    <member name="T:System.Numerics.Vector2">
-      <summary>Represents a vector with two single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector2.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector2"></see> object whose two elements have the same value.</summary>
-      <param name="value">The value to assign to both elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector2.#ctor(System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector2.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector2.Y"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector2.Abs(System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Add(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Clamp(System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector2.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector2.Distance(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.DistanceSquared(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Dot(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Equals(System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Length">
-      <summary>Returns the length of the vector.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Lerp(System.Numerics.Vector2,System.Numerics.Vector2,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Max(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Min(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Multiply(System.Single,System.Numerics.Vector2)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Negate(System.Numerics.Vector2)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Normalize(System.Numerics.Vector2)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="value">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.One">
-      <summary>Gets a vector whose 2 elements are equal to one.</summary>
-      <returns>A vector whose two elements are equal to one (that is, it returns the vector (1,1).</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Addition(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Equality(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Inequality(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Multiply(System.Single,System.Numerics.Vector2)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_Subtraction(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.op_UnaryNegation(System.Numerics.Vector2)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Reflect(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Returns the reflection of a vector off a surface that has the specified normal.</summary>
-      <param name="vector">The source vector.</param>
-      <param name="normal">The normal of the surface being reflected off.</param>
-      <returns>The reflected vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.SquareRoot(System.Numerics.Vector2)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Subtract(System.Numerics.Vector2,System.Numerics.Vector2)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
-      <summary>Transforms a vector by a specified 3x2 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
-      <summary>Transforms a vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
-      <summary>Transforms a vector normal by the given 3x2 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector normal by the given 4x4 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.UnitX">
-      <summary>Gets the vector (1,0).</summary>
-      <returns>The vector (1,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.UnitY">
-      <summary>Gets the vector (0,1).</summary>
-      <returns>The vector (0,1).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector2.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector2.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector2.Zero">
-      <summary>Returns a vector whose 2 elements are equal to zero.</summary>
-      <returns>A vector whose two elements are equal to zero (that is, it returns the vector (0,0).</returns>
-    </member>
-    <member name="T:System.Numerics.Vector3">
-      <summary>Represents a vector with three  single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector3"></see> object whose three elements have the same value.</summary>
-      <param name="value">The value to assign to all three elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Numerics.Vector2,System.Single)">
-      <summary>Creates a   new <see cref="T:System.Numerics.Vector3"></see> object from the specified <see cref="T:System.Numerics.Vector2"></see> object and the specified value.</summary>
-      <param name="value">The vector with two elements.</param>
-      <param name="z">The additional value to assign to the <see cref="F:System.Numerics.Vector3.Z"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.#ctor(System.Single,System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector3.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector3.Y"></see> field.</param>
-      <param name="z">The value to assign to the <see cref="F:System.Numerics.Vector3.Z"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector3.Abs(System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Add(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Clamp(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector3.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector3.Cross(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Computes the cross product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The cross product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Distance(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.DistanceSquared(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Dot(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Equals(System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Length">
-      <summary>Returns the length of this vector object.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Lerp(System.Numerics.Vector3,System.Numerics.Vector3,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Max(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Min(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Single,System.Numerics.Vector3)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Negate(System.Numerics.Vector3)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Normalize(System.Numerics.Vector3)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="value">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.One">
-      <summary>Gets a vector whose 3 elements are equal to one.</summary>
-      <returns>A vector whose three elements are equal to one (that is, it returns the vector (1,1,1).</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Addition(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Equality(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Inequality(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Multiply(System.Single,System.Numerics.Vector3)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_Subtraction(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.op_UnaryNegation(System.Numerics.Vector3)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Reflect(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Returns the reflection of a vector off a surface that has the specified normal.</summary>
-      <param name="vector">The source vector.</param>
-      <param name="normal">The normal of the surface being reflected off.</param>
-      <returns>The reflected vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.SquareRoot(System.Numerics.Vector3)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Subtract(System.Numerics.Vector3,System.Numerics.Vector3)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
-      <summary>Transforms a vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector3.TransformNormal(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a vector normal by the given 4x4 matrix.</summary>
-      <param name="normal">The source vector.</param>
-      <param name="matrix">The matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitX">
-      <summary>Gets the vector (1,0,0).</summary>
-      <returns>The vector (1,0,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitY">
-      <summary>Gets the vector (0,1,0).</summary>
-      <returns>The vector (0,1,0)..</returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.UnitZ">
-      <summary>Gets the vector (0,0,1).</summary>
-      <returns>The vector (0,0,1).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector3.Z">
-      <summary>The Z component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector3.Zero">
-      <summary>Gets a vector whose 3 elements are equal to zero.</summary>
-      <returns>A vector whose three elements are equal to zero (that is, it returns the vector (0,0,0).</returns>
-    </member>
-    <member name="T:System.Numerics.Vector4">
-      <summary>Represents a vector with four single-precision floating-point values.</summary>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Single)">
-      <summary>Creates a new <see cref="T:System.Numerics.Vector4"></see> object whose four elements have the same value.</summary>
-      <param name="value">The value to assign to all four elements.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector3,System.Single)">
-      <summary>Constructs a new <see cref="T:System.Numerics.Vector4"></see> object from the specified <see cref="T:System.Numerics.Vector3"></see> object and a W component.</summary>
-      <param name="value">The vector to use for the X, Y, and Z components.</param>
-      <param name="w">The W component.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector2,System.Single,System.Single)">
-      <summary>Creates a   new <see cref="T:System.Numerics.Vector4"></see> object from the specified <see cref="T:System.Numerics.Vector2"></see> object and a Z and a W component.</summary>
-      <param name="value">The vector to use for the X and Y components.</param>
-      <param name="z">The Z component.</param>
-      <param name="w">The W component.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.#ctor(System.Single,System.Single,System.Single,System.Single)">
-      <summary>Creates a vector whose elements have the specified values.</summary>
-      <param name="x">The value to assign to the <see cref="F:System.Numerics.Vector4.X"></see> field.</param>
-      <param name="y">The value to assign to the <see cref="F:System.Numerics.Vector4.Y"></see> field.</param>
-      <param name="z">The value to assign to the <see cref="F:System.Numerics.Vector4.Z"></see> field.</param>
-      <param name="w">The value to assign to the <see cref="F:System.Numerics.Vector4.W"></see> field.</param>
-    </member>
-    <member name="M:System.Numerics.Vector4.Abs(System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the absolute values of each of the specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The absolute value vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Add(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Clamp(System.Numerics.Vector4,System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Restricts a vector between a minimum and a maximum value.</summary>
-      <param name="value1">The vector to restrict.</param>
-      <param name="min">The minimum value.</param>
-      <param name="max">The maximum value.</param>
-      <returns>The restricted vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.CopyTo(System.Single[])">
-      <summary>Copies the elements of the vector to a specified array.</summary>
-      <param name="array">The destination array.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector4.CopyTo(System.Single[],System.Int32)">
-      <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
-      <param name="array">The destination array.</param>
-      <param name="index">The index at which to copy the first element of the vector.</param>
-      <exception cref="T:System.ArgumentNullException"><paramref name="array">array</paramref> is null.</exception>
-      <exception cref="T:System.ArgumentException">The number of elements in the current instance is greater than in the array.</exception>
-      <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index">index</paramref> is less than zero.  
- -or-  
- <paramref name="index">index</paramref> is greater than or equal to the array length.</exception>
-      <exception cref="T:System.RankException"><paramref name="array">array</paramref> is multidimensional.</exception>
-    </member>
-    <member name="M:System.Numerics.Vector4.Distance(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Computes the Euclidean distance between the two given points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.DistanceSquared(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns the Euclidean distance squared between two specified points.</summary>
-      <param name="value1">The first point.</param>
-      <param name="value2">The second point.</param>
-      <returns>The distance squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector resulting from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="divisor">The scalar value.</param>
-      <returns>The vector that results from the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Dot(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns the dot product of two vectors.</summary>
-      <param name="vector1">The first vector.</param>
-      <param name="vector2">The second vector.</param>
-      <returns>The dot product.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Equals(System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether this instance and another vector are equal.</summary>
-      <param name="other">The other vector.</param>
-      <returns>true if the two vectors are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Equals(System.Object)">
-      <summary>Returns a value that indicates whether this instance and a specified object are equal.</summary>
-      <param name="obj">The object to compare with the current instance.</param>
-      <returns>true if the current instance and <paramref name="obj">obj</paramref> are equal; otherwise, false. If <paramref name="obj">obj</paramref> is null, the method returns false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.GetHashCode">
-      <summary>Returns the hash code for this instance.</summary>
-      <returns>The hash code.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Length">
-      <summary>Returns the length of this vector object.</summary>
-      <returns>The vector&amp;#39;s length.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.LengthSquared">
-      <summary>Returns the length of the vector squared.</summary>
-      <returns>The vector&amp;#39;s length squared.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Lerp(System.Numerics.Vector4,System.Numerics.Vector4,System.Single)">
-      <summary>Performs a linear interpolation between two vectors based on the given weighting.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <param name="amount">A value between 0 and 1 that indicates the weight of value2.</param>
-      <returns>The interpolated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Max(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the maximum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The maximized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Min(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the minimum of each of the pairs of elements in two specified vectors.</summary>
-      <param name="value1">The first vector.</param>
-      <param name="value2">The second vector.</param>
-      <returns>The minimized vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Single)">
-      <summary>Multiplies a vector by a specified scalar.</summary>
-      <param name="left">The vector to multiply.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Multiply(System.Single,System.Numerics.Vector4)">
-      <summary>Multiplies a scalar value by a specified vector.</summary>
-      <param name="left">The scaled value.</param>
-      <param name="right">The vector.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Negate(System.Numerics.Vector4)">
-      <summary>Negates a specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Normalize(System.Numerics.Vector4)">
-      <summary>Returns a vector with the same direction as the specified vector, but with a length of one.</summary>
-      <param name="vector">The vector to normalize.</param>
-      <returns>The normalized vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.One">
-      <summary>Gets a vector whose 4 elements are equal to one.</summary>
-      <returns>Returns <see cref="System.Numerics.Vector4"></see>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Addition(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Adds two vectors together.</summary>
-      <param name="left">The first vector to add.</param>
-      <param name="right">The second vector to add.</param>
-      <returns>The summed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Divides the first vector by the second.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from dividing <paramref name="left">left</paramref> by <paramref name="right">right</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Single)">
-      <summary>Divides the specified vector by a specified scalar value.</summary>
-      <param name="value1">The vector.</param>
-      <param name="value2">The scalar value.</param>
-      <returns>The result of the division.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Equality(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether each pair of elements in two specified vectors is equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Inequality(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Returns a value that indicates whether two specified vectors are not equal.</summary>
-      <param name="left">The first vector to compare.</param>
-      <param name="right">The second vector to compare.</param>
-      <returns>true if <paramref name="left">left</paramref> and <paramref name="right">right</paramref> are not equal; otherwise, false.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Multiplies two vectors together.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The product vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Single)">
-      <summary>Multiples the specified vector by the specified scalar value.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Multiply(System.Single,System.Numerics.Vector4)">
-      <summary>Multiples the scalar value by the specified vector.</summary>
-      <param name="left">The vector.</param>
-      <param name="right">The scalar value.</param>
-      <returns>The scaled vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_Subtraction(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The vector that results from subtracting <paramref name="right">right</paramref> from <paramref name="left">left</paramref>.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.op_UnaryNegation(System.Numerics.Vector4)">
-      <summary>Negates the specified vector.</summary>
-      <param name="value">The vector to negate.</param>
-      <returns>The negated vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.SquareRoot(System.Numerics.Vector4)">
-      <summary>Returns a vector whose elements are the square root of each of a specified vector&amp;#39;s elements.</summary>
-      <param name="value">A vector.</param>
-      <returns>The square root vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Subtract(System.Numerics.Vector4,System.Numerics.Vector4)">
-      <summary>Subtracts the second vector from the first.</summary>
-      <param name="left">The first vector.</param>
-      <param name="right">The second vector.</param>
-      <returns>The difference vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString">
-      <summary>Returns the string representation of the current instance using default formatting.</summary>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString(System.String)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.ToString(System.String,System.IFormatProvider)">
-      <summary>Returns the string representation of the current instance using the specified format string to format individual elements and the specified format provider to define culture-specific formatting.</summary>
-      <param name="format">A  or  that defines the format of individual elements.</param>
-      <param name="formatProvider">A format provider that supplies culture-specific formatting information.</param>
-      <returns>The string representation of the current instance.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Quaternion)">
-      <summary>Transforms a four-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Matrix4x4)">
-      <summary>Transforms a four-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="vector">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
-      <summary>Transforms a three-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
-      <summary>Transforms a two-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
-      <summary>Transforms a two-dimensional vector by the specified Quaternion rotation value.</summary>
-      <param name="value">The vector to rotate.</param>
-      <param name="rotation">The rotation to apply.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
-      <summary>Transforms a three-dimensional vector by a specified 4x4 matrix.</summary>
-      <param name="position">The vector to transform.</param>
-      <param name="matrix">The transformation matrix.</param>
-      <returns>The transformed vector.</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitW">
-      <summary>Gets the vector (0,0,0,1).</summary>
-      <returns>The vector (0,0,0,1).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitX">
-      <summary>Gets the vector (1,0,0,0).</summary>
-      <returns>The vector (1,0,0,0).</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitY">
-      <summary>Gets the vector (0,1,0,0).</summary>
-      <returns>The vector (0,1,0,0)..</returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.UnitZ">
-      <summary>Gets a vector whose 4 elements are equal to zero.</summary>
-      <returns>The vector (0,0,1,0).</returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.W">
-      <summary>The W component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.X">
-      <summary>The X component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.Y">
-      <summary>The Y component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="F:System.Numerics.Vector4.Z">
-      <summary>The Z component of the vector.</summary>
-      <returns></returns>
-    </member>
-    <member name="P:System.Numerics.Vector4.Zero">
-      <summary>Gets a vector whose 4 elements are equal to zero.</summary>
-      <returns>A vector whose four elements are equal to zero (that is, it returns the vector (0,0,0,0).</returns>
-    </member>
-  </members>
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Numerics.Vectors</name>
+    </assembly>
+    <members>
+        <member name="T:System.Numerics.Matrix3x2">
+            <summary>
+            A structure encapsulating a 3x2 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M11">
+            <summary>
+            The first element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M12">
+            <summary>
+            The second element of the first row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M21">
+            <summary>
+            The first element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M22">
+            <summary>
+            The second element of the second row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M31">
+            <summary>
+            The first element of the third row
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix3x2.M32">
+            <summary>
+            The second element of the third row
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix3x2.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix3x2 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Numerics.Vector2)">
+            <summary>
+            Creates a translation matrix from the given vector.
+            </summary>
+            <param name="position">The translation position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateTranslation(System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix from the given X and Y components.
+            </summary>
+            <param name="xPosition">The X position.</param>
+            <param name="yPosition">The Y position.</param>
+            <returns>A translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single)">
+            <summary>
+            Creates a scale matrix from the given X and Y components.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that is offset by a given center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix from the given vector scale with an offset from the given center point.
+            </summary>
+            <param name="scales">The scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateScale(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a scale matrix that scales uniformly with the given scale with an offset from the given center.
+            </summary>
+            <param name="scale">The uniform scale to use.</param>
+            <param name="centerPoint">The center offset.</param>
+            <returns>A scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single)">
+            <summary>
+            Creates a skew matrix from the given angles in radians.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateSkew(System.Single,System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a skew matrix from the given angles in radians and a center point.
+            </summary>
+            <param name="radiansX">The X angle, in radians.</param>
+            <param name="radiansY">The Y angle, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A skew matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.CreateRotation(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Creates a rotation matrix using the given rotation in radians and a center point.
+            </summary>
+            <param name="radians">The amount of rotation, in radians.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>A rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetDeterminant">
+            <summary>
+            Calculates the determinant for this matrix. 
+            The determinant is calculated by expanding the matrix with a third column whose values are (0,0,1).
+            </summary>
+            <returns>The determinant.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Invert(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2@)">
+            <summary>
+            Attempts to invert the given matrix. If the operation succeeds, the inverted matrix is stored in the result parameter.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="result">The output matrix.</param>
+            <returns>True if the operation succeeded, False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Lerp(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Linearly interpolates from matrix1 to matrix2, based on the third parameter.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weighting of matrix2.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Negate(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Add(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Subtract(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_UnaryNegation(System.Numerics.Matrix3x2)">
+            <summary>
+            Negates the given matrix by multiplying all values by -1.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Addition(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Adds each matrix element in value1 with its corresponding element in value2.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the summed values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Subtraction(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Subtracts each matrix element in value2 from its corresponding element in value1.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The matrix containing the resulting values.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Multiplies two matrices together and returns the resulting matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The product matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Multiply(System.Numerics.Matrix3x2,System.Single)">
+            <summary>
+            Scales all elements in a matrix by the given scalar factor.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling value to use.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Equality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.op_Inequality(System.Numerics.Matrix3x2,System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the given matrices are not equal.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>True if the matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Numerics.Matrix3x2)">
+            <summary>
+            Returns a boolean indicating whether the matrix is equal to the other given matrix.
+            </summary>
+            <param name="other">The other matrix to test equality against.</param>
+            <returns>True if this matrix is equal to other; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix3x2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Matrix4x4">
+            <summary>
+            A structure encapsulating a 4x4 matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M11">
+            <summary>
+            Value at row 1, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M12">
+            <summary>
+            Value at row 1, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M13">
+            <summary>
+            Value at row 1, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M14">
+            <summary>
+            Value at row 1, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M21">
+            <summary>
+            Value at row 2, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M22">
+            <summary>
+            Value at row 2, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M23">
+            <summary>
+            Value at row 2, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M24">
+            <summary>
+            Value at row 2, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M31">
+            <summary>
+            Value at row 3, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M32">
+            <summary>
+            Value at row 3, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M33">
+            <summary>
+            Value at row 3, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M34">
+            <summary>
+            Value at row 3, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M41">
+            <summary>
+            Value at row 4, column 1 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M42">
+            <summary>
+            Value at row 4, column 2 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M43">
+            <summary>
+            Value at row 4, column 3 of the matrix.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Matrix4x4.M44">
+            <summary>
+            Value at row 4, column 4 of the matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Identity">
+            <summary>
+            Returns the multiplicative identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.IsIdentity">
+            <summary>
+            Returns whether the matrix is the identity matrix.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Matrix4x4.Translation">
+            <summary>
+            Gets or sets the translation component of this matrix.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Matrix4x4 from the given components.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.#ctor(System.Numerics.Matrix3x2)">
+            <summary>
+            Constructs a Matrix4x4 from the given Matrix3x2.
+            </summary>
+            <param name="value">The source Matrix3x2.</param>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a spherical billboard that rotates around a specified object position.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="cameraUpVector">The up vector of the camera.</param>
+            <param name="cameraForwardVector">The forward vector of the camera.</param>
+            <returns>The created billboard matrix</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateConstrainedBillboard(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a cylindrical billboard that rotates around a specified axis.
+            </summary>
+            <param name="objectPosition">Position of the object the billboard will rotate around.</param>
+            <param name="cameraPosition">Position of the camera.</param>
+            <param name="rotateAxis">Axis to rotate the billboard around.</param>
+            <param name="cameraForwardVector">Forward vector of the camera.</param>
+            <param name="objectForwardVector">Forward vector of the object.</param>
+            <returns>The created billboard matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Numerics.Vector3)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="position">The amount to translate in each axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateTranslation(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix.
+            </summary>
+            <param name="xPosition">The amount to translate on the X-axis.</param>
+            <param name="yPosition">The amount to translate on the Y-axis.</param>
+            <param name="zPosition">The amount to translate on the Z-axis.</param>
+            <returns>The translation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Single,System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="xScale">Value to scale by on the X-axis.</param>
+            <param name="yScale">Value to scale by on the Y-axis.</param>
+            <param name="zScale">Value to scale by on the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a scaling matrix with a center point.
+            </summary>
+            <param name="scales">The vector containing the amount to scale by on each axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateScale(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a uniform scaling matrix that scales equally on each axis with a center point.
+            </summary>
+            <param name="scale">The uniform scaling factor.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The scaling matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationX(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the X-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the X-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationY(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Y-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Y-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateRotationZ(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Creates a matrix for rotating points around the Z-axis, from a center point.
+            </summary>
+            <param name="radians">The amount, in radians, by which to rotate around the Z-axis.</param>
+            <param name="centerPoint">The center point.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a matrix that rotates around an arbitrary vector.
+            </summary>
+            <param name="axis">The axis to rotate around.</param>
+            <param name="angle">The angle to rotate around the given axis, in radians.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveFieldOfView(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix based on a field of view, aspect ratio, and near and far view plane distances. 
+            </summary>
+            <param name="fieldOfView">Field of view in the y direction, in radians.</param>
+            <param name="aspectRatio">Aspect ratio, defined as view space width divided by height.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspective(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a perspective projection matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume at the near view plane.</param>
+            <param name="height">Height of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreatePerspectiveOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a customized, perspective projection matrix.
+            </summary>
+            <param name="left">Minimum x-value of the view volume at the near view plane.</param>
+            <param name="right">Maximum x-value of the view volume at the near view plane.</param>
+            <param name="bottom">Minimum y-value of the view volume at the near view plane.</param>
+            <param name="top">Maximum y-value of the view volume at the near view plane.</param>
+            <param name="nearPlaneDistance">Distance to the near view plane.</param>
+            <param name="farPlaneDistance">Distance to of the far view plane.</param>
+            <returns>The perspective projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographic(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates an orthographic perspective matrix from the given view volume dimensions.
+            </summary>
+            <param name="width">Width of the view volume.</param>
+            <param name="height">Height of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateOrthographicOffCenter(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Builds a customized, orthographic projection matrix.
+            </summary>
+            <param name="left">Minimum X-value of the view volume.</param>
+            <param name="right">Maximum X-value of the view volume.</param>
+            <param name="bottom">Minimum Y-value of the view volume.</param>
+            <param name="top">Maximum Y-value of the view volume.</param>
+            <param name="zNearPlane">Minimum Z-value of the view volume.</param>
+            <param name="zFarPlane">Maximum Z-value of the view volume.</param>
+            <returns>The orthographic projection matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateLookAt(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a view matrix.
+            </summary>
+            <param name="cameraPosition">The position of the camera.</param>
+            <param name="cameraTarget">The target towards which the camera is pointing.</param>
+            <param name="cameraUpVector">The direction that is "up" from the camera's point of view.</param>
+            <returns>The view matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateWorld(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a world matrix with the specified parameters.
+            </summary>
+            <param name="position">The position of the object; used in translation operations.</param>
+            <param name="forward">Forward direction of the object.</param>
+            <param name="up">Upward direction of the object; usually [0, 1, 0].</param>
+            <returns>The world matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromQuaternion(System.Numerics.Quaternion)">
+            <summary>
+            Creates a rotation matrix from the given Quaternion rotation value.
+            </summary>
+            <param name="quaternion">The source Quaternion.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a rotation matrix from the specified yaw, pitch, and roll.
+            </summary>
+            <param name="yaw">Angle of rotation, in radians, around the Y-axis.</param>
+            <param name="pitch">Angle of rotation, in radians, around the X-axis.</param>
+            <param name="roll">Angle of rotation, in radians, around the Z-axis.</param>
+            <returns>The rotation matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateShadow(System.Numerics.Vector3,System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that flattens geometry into a specified Plane as if casting a shadow from a specified light source.
+            </summary>
+            <param name="lightDirection">The direction from which the light that will cast the shadow is coming.</param>
+            <param name="plane">The Plane onto which the new matrix should flatten geometry so as to cast a shadow.</param>
+            <returns>A new Matrix that can be used to flatten geometry onto the specified plane from the specified direction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.CreateReflection(System.Numerics.Plane)">
+            <summary>
+            Creates a Matrix that reflects the coordinate system about a specified Plane.
+            </summary>
+            <param name="value">The Plane about which to create a reflection.</param>
+            <returns>A new matrix expressing the reflection.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetDeterminant">
+            <summary>
+            Calculates the determinant of the matrix.
+            </summary>
+            <returns>The determinant of the matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Invert(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4@)">
+            <summary>
+            Attempts to calculate the inverse of the given matrix. If successful, result will contain the inverted matrix.
+            </summary>
+            <param name="matrix">The source matrix to invert.</param>
+            <param name="result">If successful, contains the inverted matrix.</param>
+            <returns>True if the source matrix could be inverted; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Decompose(System.Numerics.Matrix4x4,System.Numerics.Vector3@,System.Numerics.Quaternion@,System.Numerics.Vector3@)">
+            <summary>
+            Attempts to extract the scale, translation, and rotation components from the given scale/rotation/translation matrix.
+            If successful, the out parameters will contained the extracted values.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <param name="scale">The scaling component of the transformation matrix.</param>
+            <param name="rotation">The rotation component of the transformation matrix.</param>
+            <param name="translation">The translation component of the transformation matrix</param>
+            <returns>True if the source matrix was successfully decomposed; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transform(System.Numerics.Matrix4x4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms the given matrix by applying the given Quaternion rotation.
+            </summary>
+            <param name="value">The source matrix to transform.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Transpose(System.Numerics.Matrix4x4)">
+            <summary>
+            Transposes the rows and columns of a matrix.
+            </summary>
+            <param name="matrix">The source matrix.</param>
+            <returns>The transposed matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Lerp(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Linearly interpolates between the corresponding values of two matrices.
+            </summary>
+            <param name="matrix1">The first source matrix.</param>
+            <param name="matrix2">The second source matrix.</param>
+            <param name="amount">The relative weight of the second source matrix.</param>
+            <returns>The interpolated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Negate(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Add(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Subtract(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_UnaryNegation(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a new matrix with the negated elements of the given matrix.
+            </summary>
+            <param name="value">The source matrix.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Addition(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Adds two matrices together.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The resulting matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Subtraction(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Subtracts the second matrix from the first.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Multiplies a matrix by another matrix.
+            </summary>
+            <param name="value1">The first source matrix.</param>
+            <param name="value2">The second source matrix.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Multiply(System.Numerics.Matrix4x4,System.Single)">
+            <summary>
+            Multiplies a matrix by a scalar value.
+            </summary>
+            <param name="value1">The source matrix.</param>
+            <param name="value2">The scaling factor.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Equality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.op_Inequality(System.Numerics.Matrix4x4,System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether the given two matrices are not equal.
+            </summary>
+            <param name="value1">The first matrix to compare.</param>
+            <param name="value2">The second matrix to compare.</param>
+            <returns>True if the given matrices are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Numerics.Matrix4x4)">
+            <summary>
+            Returns a boolean indicating whether this matrix instance is equal to the other given matrix.
+            </summary>
+            <param name="other">The matrix to compare this instance to.</param>
+            <returns>True if the matrices are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this matrix instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this matrix; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.ToString">
+            <summary>
+            Returns a String representing this matrix instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Matrix4x4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Plane">
+            <summary>
+            A structure encapsulating a 3D Plane
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.Normal">
+            <summary>
+            The normal vector of the Plane.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Plane.D">
+            <summary>
+            The distance of the Plane along its normal from the origin.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Plane from the X, Y, and Z components of its normal, and its distance from the origin on that normal.
+            </summary>
+            <param name="x">The X-component of the normal.</param>
+            <param name="y">The Y-component of the normal.</param>
+            <param name="z">The Z-component of the normal.</param>
+            <param name="d">The distance of the Plane along its normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Plane from the given normal and distance along the normal from the origin.
+            </summary>
+            <param name="normal">The Plane's normal vector.</param>
+            <param name="d">The Plane's distance from the origin along its normal vector.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.#ctor(System.Numerics.Vector4)">
+            <summary>
+            Constructs a Plane from the given Vector4.
+            </summary>
+            <param name="value">A vector whose first 3 elements describe the normal vector, 
+            and whose W component defines the distance along that normal from the origin.</param>
+        </member>
+        <member name="M:System.Numerics.Plane.CreateFromVertices(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Creates a Plane that contains the three given points.
+            </summary>
+            <param name="point1">The first point defining the Plane.</param>
+            <param name="point2">The second point defining the Plane.</param>
+            <param name="point3">The third point defining the Plane.</param>
+            <returns>The Plane containing the three points.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Normalize(System.Numerics.Plane)">
+            <summary>
+            Creates a new Plane whose normal vector is the source Plane's normal vector normalized.
+            </summary>
+            <param name="value">The source Plane.</param>
+            <returns>The normalized Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a normalized Plane by a Matrix.
+            </summary>
+            <param name="plane"> The normalized Plane to transform. 
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="matrix">The transformation matrix to apply to the Plane.</param>
+            <returns>The transformed Plane.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Transform(System.Numerics.Plane,System.Numerics.Quaternion)">
+            <summary>
+             Transforms a normalized Plane by a Quaternion rotation.
+            </summary>
+            <param name="plane"> The normalized Plane to transform.
+            This Plane must already be normalized, so that its Normal vector is of unit length, before this method is called.</param>
+            <param name="rotation">The Quaternion rotation to apply to the Plane.</param>
+            <returns>A new Plane that results from applying the rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Dot(System.Numerics.Plane,System.Numerics.Vector4)">
+            <summary>
+            Calculates the dot product of a Plane and Vector4.
+            </summary>
+            <param name="plane">The Plane.</param>
+            <param name="value">The Vector4.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotCoordinate(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the normal vector of this Plane plus the distance (D) value of the Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting value.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.DotNormal(System.Numerics.Plane,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of a specified Vector3 and the Normal vector of this Plane.
+            </summary>
+            <param name="plane">The plane.</param>
+            <param name="value">The Vector3.</param>
+            <returns>The resulting dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Equality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.op_Inequality(System.Numerics.Plane,System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the two given Planes are not equal.
+            </summary>
+            <param name="value1">The first Plane to compare.</param>
+            <param name="value2">The second Plane to compare.</param>
+            <returns>True if the Planes are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Numerics.Plane)">
+            <summary>
+            Returns a boolean indicating whether the given Plane is equal to this Plane instance.
+            </summary>
+            <param name="other">The Plane to compare this instance to.</param>
+            <returns>True if the other Plane is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Plane instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Plane; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.ToString">
+            <summary>
+            Returns a String representing this Plane instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Plane.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Quaternion">
+            <summary>
+            A structure encapsulating a four-dimensional vector (x,y,z,w), 
+            which is used to efficiently rotate an object about the (x,y,z) vector by the angle theta, where w = cos(theta/2).
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.X">
+            <summary>
+            Specifies the X-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Y">
+            <summary>
+            Specifies the Y-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.Z">
+            <summary>
+            Specifies the Z-value of the vector component of the Quaternion.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Quaternion.W">
+            <summary>
+            Specifies the rotation component of the Quaternion.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.Identity">
+            <summary>
+            Returns a Quaternion representing no rotation. 
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Quaternion.IsIdentity">
+            <summary>
+            Returns whether the Quaternion is the identity Quaternion.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given components.
+            </summary>
+            <param name="x">The X component of the Quaternion.</param>
+            <param name="y">The Y component of the Quaternion.</param>
+            <param name="z">The Z component of the Quaternion.</param>
+            <param name="w">The W component of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Quaternion from the given vector and rotation parts.
+            </summary>
+            <param name="vectorPart">The vector part of the Quaternion.</param>
+            <param name="scalarPart">The rotation part of the Quaternion.</param>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Length">
+            <summary>
+            Calculates the length of the Quaternion.
+            </summary>
+            <returns>The computed length of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.LengthSquared">
+            <summary>
+            Calculates the length squared of the Quaternion. This operation is cheaper than Length().
+            </summary>
+            <returns>The length squared of the Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Normalize(System.Numerics.Quaternion)">
+            <summary>
+            Divides each component of the Quaternion by the length of the Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The normalized Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Conjugate(System.Numerics.Quaternion)">
+            <summary>
+            Creates the conjugate of a specified Quaternion.
+            </summary>
+            <param name="value">The Quaternion of which to return the conjugate.</param>
+            <returns>A new Quaternion that is the conjugate of the specified one.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Inverse(System.Numerics.Quaternion)">
+            <summary>
+            Returns the inverse of a Quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The inverted Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromAxisAngle(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Creates a Quaternion from a normalized vector axis and an angle to rotate about the vector.
+            </summary>
+            <param name="axis">The unit vector to rotate around.
+            This vector must be normalized before calling this function or the resulting Quaternion will be incorrect.</param>
+            <param name="angle">The angle, in radians, to rotate around the vector.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromYawPitchRoll(System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a new Quaternion from the given yaw, pitch, and roll, in radians.
+            </summary>
+            <param name="yaw">The yaw angle, in radians, around the Y-axis.</param>
+            <param name="pitch">The pitch angle, in radians, around the X-axis.</param>
+            <param name="roll">The roll angle, in radians, around the Z-axis.</param>
+            <returns></returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.CreateFromRotationMatrix(System.Numerics.Matrix4x4)">
+            <summary>
+            Creates a Quaternion from the given rotation matrix.
+            </summary>
+            <param name="matrix">The rotation matrix.</param>
+            <returns>The created Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Dot(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Calculates the dot product of two Quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <returns>The dot product of the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Slerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Interpolates between two quaternions, using spherical linear interpolation.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Lerp(System.Numerics.Quaternion,System.Numerics.Quaternion,System.Single)">
+            <summary>
+             Linearly interpolates between two quaternions.
+            </summary>
+            <param name="quaternion1">The first source Quaternion.</param>
+            <param name="quaternion2">The second source Quaternion.</param>
+            <param name="amount">The relative weight of the second source Quaternion in the interpolation.</param>
+            <returns>The interpolated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Concatenate(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Concatenates two Quaternions; the result represents the value1 rotation followed by the value2 rotation.
+            </summary>
+            <param name="value1">The first Quaternion rotation in the series.</param>
+            <param name="value2">The second Quaternion rotation in the series.</param>
+            <returns>A new Quaternion representing the concatenation of the value1 rotation followed by the value2 rotation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Negate(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Add(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Subtract(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Divide(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_UnaryNegation(System.Numerics.Quaternion)">
+            <summary>
+            Flips the sign of each component of the quaternion.
+            </summary>
+            <param name="value">The source Quaternion.</param>
+            <returns>The negated Quaternion.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Addition(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Adds two Quaternions element-by-element.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second source Quaternion.</param>
+            <returns>The result of adding the Quaternions.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Subtraction(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Subtracts one Quaternion from another.
+            </summary>
+            <param name="value1">The first source Quaternion.</param>
+            <param name="value2">The second Quaternion, to be subtracted from the first.</param>
+            <returns>The result of the subtraction.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Multiplies two Quaternions together.
+            </summary>
+            <param name="value1">The Quaternion on the left side of the multiplication.</param>
+            <param name="value2">The Quaternion on the right side of the multiplication.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Multiply(System.Numerics.Quaternion,System.Single)">
+            <summary>
+            Multiplies a Quaternion by a scalar value.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the multiplication.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Division(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Divides a Quaternion by another Quaternion.
+            </summary>
+            <param name="value1">The source Quaternion.</param>
+            <param name="value2">The divisor.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Equality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.op_Inequality(System.Numerics.Quaternion,System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the two given Quaternions are not equal.
+            </summary>
+            <param name="value1">The first Quaternion to compare.</param>
+            <param name="value2">The second Quaternion to compare.</param>
+            <returns>True if the Quaternions are not equal; False if they are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Numerics.Quaternion)">
+            <summary>
+            Returns a boolean indicating whether the given Quaternion is equal to this Quaternion instance.
+            </summary>
+            <param name="other">The Quaternion to compare this instance to.</param>
+            <returns>True if the other Quaternion is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Quaternion instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.ToString">
+            <summary>
+            Returns a String representing this Quaternion instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Quaternion.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="T:System.Numerics.Register">
+            <summary>
+            A structure describing the layout of an SSE2-sized register.
+            Contains overlapping fields representing the set of valid numeric types.
+            Allows the generic Vector'T struct to contain an explicit field layout.
+            </summary>
+        </member>
+        <member name="T:System.Numerics.Vector`1">
+            <summary>
+            A structure that represents a single Vector. The count of this Vector is fixed but CPU register dependent.
+            This struct only supports numerical types. This type is intended to be used as a building block for vectorizing
+            large algorithms. This type is immutable, individual elements cannot be modified.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Count">
+            <summary>
+            Returns the number of elements stored in the vector. This value is hardware dependent.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Zero">
+            <summary>
+            Returns a vector containing all zeroes.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector`1.One">
+            <summary>
+            Returns a vector containing all ones.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0)">
+            <summary>
+            Constructs a vector whose components are all <code>value</code>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[])">
+            <summary>
+            Constructs a vector from the given array. The size of the given array must be at least Vector'T.Count.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.#ctor(`0[],System.Int32)">
+            <summary>
+            Constructs a vector from the given array, starting from the given index.
+            The array must contain at least Vector'T.Count from the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[])">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="M:System.Numerics.Vector`1.CopyTo(`0[],System.Int32)">
+            <summary>
+            Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
+            </summary>
+            <param name="destination">The destination array which the values are copied into</param>
+            <param name="startIndex">The index to start copying to</param>
+            <exception cref="T:System.ArgumentNullException">If the destination array is null</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
+        </member>
+        <member name="P:System.Numerics.Vector`1.Item(System.Int32)">
+            <summary>
+            Returns the element at the given index.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this vector instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this vector; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.Equals(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether the given vector is equal to this vector instance.
+            </summary>
+            <param name="other">The vector to compare this instance to.</param>
+            <returns>True if the other vector is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString">
+            <summary>
+            Returns a String representing this vector.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this vector, using the specified format string to format individual elements
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Addition(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Subtraction(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(System.Numerics.Vector{`0},`0)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="value">The source vector.</param>
+            <param name="factor">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Multiply(`0,System.Numerics.Vector{`0})">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="factor">The scalar value.</param>
+            <param name="value">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Division(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_UnaryNegation(System.Numerics.Vector{`0})">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseAnd(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_BitwiseOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_ExclusiveOr(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_OnesComplement(System.Numerics.Vector{`0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Equality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Inequality(System.Numerics.Vector{`0},System.Numerics.Vector{`0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if left and right are not equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Byte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.SByte}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int16}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int32}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.UInt64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Int64}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Single}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector`1.op_Explicit(System.Numerics.Vector{`0})~System.Numerics.Vector{System.Double}">
+            <summary>
+            Reinterprets the bits of the given vector into those of another type.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector">
+            <summary>
+            Contains various methods useful for creating, manipulating, combining, and converting generic vectors with one another.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt16}@,System.Numerics.Vector{System.UInt16}@)">
+            <summary>
+            Widens a Vector{Byte} into two Vector{UInt16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32}@,System.Numerics.Vector{System.UInt32}@)">
+            <summary>
+            Widens a Vector{UInt16} into two Vector{UInt32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt64}@,System.Numerics.Vector{System.UInt64}@)">
+            <summary>
+            Widens a Vector{UInt32} into two Vector{UInt64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.Int16}@,System.Numerics.Vector{System.Int16}@)">
+            <summary>
+            Widens a Vector{SByte} into two Vector{Int16}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int32}@,System.Numerics.Vector{System.Int32}@)">
+            <summary>
+            Widens a Vector{Int16} into two Vector{Int32}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int64}@,System.Numerics.Vector{System.Int64}@)">
+            <summary>
+            Widens a Vector{Int32} into two Vector{Int64}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Widen(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Double}@,System.Numerics.Vector{System.Double}@)">
+            <summary>
+            Widens a Vector{Single} into two Vector{Double}'s.
+            <param name="source">The source vector whose elements are widened into the outputs.</param>
+            <param name="low">The first output vector, whose elements will contain the widened elements from lower indices in the source vector.</param>
+            <param name="high">The second output vector, whose elements will contain the widened elements from higher indices in the source vector.</param>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt16})">
+            <summary>
+            Narrows two Vector{UInt16}'s into one Vector{Byte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Byte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Narrows two Vector{UInt32}'s into one Vector{UInt16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Narrows two Vector{UInt64}'s into one Vector{UInt32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{UInt32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.Int16})">
+            <summary>
+            Narrows two Vector{Int16}'s into one Vector{SByte}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{SByte} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Narrows two Vector{Int32}'s into one Vector{Int16}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int16} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Narrows two Vector{Int64}'s into one Vector{Int32}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Int32} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Narrow(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Narrows two Vector{Double}'s into one Vector{Single}.
+            <param name="low">The first source vector, whose elements become the lower-index elements of the return value.</param>
+            <param name="high">The second source vector, whose elements become the higher-index elements of the return value.</param>
+            <returns>A Vector{Single} containing elements narrowed from the source vectors.</returns>
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.Int32})">
+            <summary>
+            Converts a Vector{Int32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToSingle(System.Numerics.Vector{System.UInt32})">
+            <summary>
+            Converts a Vector{UInt32} to a Vector{Single}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.Int64})">
+            <summary>
+            Converts a Vector{Int64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToDouble(System.Numerics.Vector{System.UInt64})">
+            <summary>
+            Converts a Vector{UInt64} to a Vector{Double}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{Int32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt32(System.Numerics.Vector{System.Single})">
+            <summary>
+            Converts a Vector{Single} to a Vector{UInt32}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{Int64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConvertToUInt64(System.Numerics.Vector{System.Double})">
+            <summary>
+            Converts a Vector{Double} to a Vector{UInt64}.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The converted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The integral mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.ConditionalSelect``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector with elements selected between the two given source vectors, and based on a mask vector.
+            </summary>
+            <param name="condition">The mask vector used to drive selection.</param>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The new vector with elements selected based on the mask.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether elements in the left and right floating point vectors were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Equals(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left and right were equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether each pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The first vector to compare.</param>
+            <returns>True if all elements are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.EqualsAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any single pair of elements in the given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any element pairs are equal; False if no element pairs are equal.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are less than their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were less than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are less than or equal to their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are less than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.LessThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is less than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are less than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThan(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all elements in left are greater than the corresponding elements in right.
+            elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Single},System.Numerics.Vector{System.Single})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.Int32})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Int64},System.Numerics.Vector{System.Int64})">
+            <summary>
+            Returns a new vector whose elements signal whether the elements in left were greater than or equal to their
+            corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqual(System.Numerics.Vector{System.Double},System.Numerics.Vector{System.Double})">
+            <summary>
+            Returns an integral vector whose elements signal whether the elements in left were greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>The resultant integral vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAll``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether all of the elements in left are greater than or equal to 
+            their corresponding elements in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if all elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.GreaterThanOrEqualAny``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a boolean indicating whether any element in left is greater than or equal to its corresponding element in right.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if any elements in left are greater than or equal to their corresponding elements in right; False otherwise.</returns>
+        </member>
+        <member name="P:System.Numerics.Vector.IsHardwareAccelerated">
+            <summary>
+            Returns whether or not vector operations are subject to hardware acceleration through JIT intrinsic support.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector.Abs``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the absolute values of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Min``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the minimum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The minimum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Max``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the maximum of each pair of elements in the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The maximum vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Dot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.SquareRoot``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the square roots of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Add``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the sum of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Subtract``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the difference between each pairs of elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Creates a new vector whose values are the product of each pair of elements from the two given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(System.Numerics.Vector{``0},``0)">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar factor.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Multiply``1(``0,System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the values of the given vector each multiplied by a scalar value.
+            </summary>
+            <param name="left">The scalar factor.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Divide``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose values are the result of dividing the first vector's elements 
+            by the corresponding elements in the second vector.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The divided vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Negate``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are the given vector's elements negated.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseAnd``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.BitwiseOr``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.OnesComplement``1(System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector whose elements are obtained by taking the one's complement of the given vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The one's complement vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.Xor``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-exclusive-or operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AndNot``1(System.Numerics.Vector{``0},System.Numerics.Vector{``0})">
+            <summary>
+            Returns a new vector by performing a bitwise-and-not operation on each of the elements in the given vectors.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The resultant vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSByte``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed bytes.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt16``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 16-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt32``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 32-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorUInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of unsigned 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorInt64``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of signed 64-bit integers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorSingle``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 32-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector.AsVectorDouble``1(System.Numerics.Vector{``0})">
+            <summary>
+            Reinterprets the bits of the given vector into those of a vector of 64-bit floating point numbers.
+            </summary>
+            <param name="value">The source vector</param>
+            <returns>The reinterpreted vector.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector2">
+            <summary>
+            A structure encapsulating two single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.Zero">
+            <summary>
+            Returns the vector (0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.One">
+            <summary>
+            Returns the vector (1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitX">
+            <summary>
+            Returns the vector (1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector2.UnitY">
+            <summary>
+            Returns the vector (0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector2 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector2; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString">
+            <summary>
+            Returns a String representing this Vector2 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector2 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Distance(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.DistanceSquared(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Normalize(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Reflect(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Clamp(System.Numerics.Vector2,System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.Lerp(System.Numerics.Vector2,System.Numerics.Vector2,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix3x2)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.TransformNormal(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Add(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Subtract(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Divide(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Negate(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector2.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector2.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.#ctor(System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+            <param name="array">The destination array.</param>
+        </member>
+        <member name="M:System.Numerics.Vector2.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from the given index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array
+            or if there are not enough elements to copy.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector2.Equals(System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the given Vector2 is equal to this Vector2 instance.
+            </summary>
+            <param name="other">The Vector2 to compare this instance to.</param>
+            <returns>True if the other Vector2 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Dot(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="value1">The first vector.</param>
+            <param name="value2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Min(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Max(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors
+            </summary>
+            <param name="value1">The first source vector</param>
+            <param name="value2">The second source vector</param>
+            <returns>The maximized vector</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.Abs(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>        
+        </member>
+        <member name="M:System.Numerics.Vector2.SquareRoot(System.Numerics.Vector2)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Addition(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Subtraction(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Single,System.Numerics.Vector2)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Multiply(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Division(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_UnaryNegation(System.Numerics.Vector2)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Equality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector2.op_Inequality(System.Numerics.Vector2,System.Numerics.Vector2)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector3">
+            <summary>
+            A structure encapsulating three single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.Zero">
+            <summary>
+            Returns the vector (0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.One">
+            <summary>
+            Returns the vector (1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitX">
+            <summary>
+            Returns the vector (1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitY">
+            <summary>
+            Returns the vector (0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector3.UnitZ">
+            <summary>
+            Returns the vector (0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector3 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString">
+            <summary>
+            Returns a String representing this Vector3 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector3 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Length">
+            <summary>
+            Returns the length of the vector.
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.LengthSquared">
+            <summary>
+            Returns the length of the vector squared. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Distance(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.DistanceSquared(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Normalize(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="value">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Cross(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Computes the cross product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The cross product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Reflect(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the reflection of a vector off a surface that has the specified normal.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="normal">The normal of the surface being reflected off.</param>
+            <returns>The reflected vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Clamp(System.Numerics.Vector3,System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Lerp(System.Numerics.Vector3,System.Numerics.Vector3,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.TransformNormal(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector normal by the given matrix.
+            </summary>
+            <param name="normal">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Add(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Subtract(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Divide(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Negate(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector3.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector3.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Numerics.Vector2,System.Single)">
+            <summary>
+            Constructs a Vector3 from the given Vector2 and a third value.
+            </summary>
+            <param name="value">The Vector to extract X and Y components from.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.#ctor(System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="x">The X component.</param>
+            <param name="y">The Y component.</param>
+            <param name="z">The Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector3.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector3.Equals(System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the given Vector3 is equal to this Vector3 instance.
+            </summary>
+            <param name="other">The Vector3 to compare this instance to.</param>
+            <returns>True if the other Vector3 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Dot(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Min(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Max(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.Abs(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.SquareRoot(System.Numerics.Vector3)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Addition(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Subtraction(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Multiply(System.Single,System.Numerics.Vector3)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Division(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_UnaryNegation(System.Numerics.Vector3)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Equality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector3.op_Inequality(System.Numerics.Vector3,System.Numerics.Vector3)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="T:System.Numerics.Vector4">
+            <summary>
+            A structure encapsulating four single precision floating point values and provides hardware accelerated methods.
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.Zero">
+            <summary>
+            Returns the vector (0,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.One">
+            <summary>
+            Returns the vector (1,1,1,1).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitX">
+            <summary>
+            Returns the vector (1,0,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitY">
+            <summary>
+            Returns the vector (0,1,0,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitZ">
+            <summary>
+            Returns the vector (0,0,1,0).
+            </summary>
+        </member>
+        <member name="P:System.Numerics.Vector4.UnitW">
+            <summary>
+            Returns the vector (0,0,0,1).
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.GetHashCode">
+            <summary>
+            Returns the hash code for this instance.
+            </summary>
+            <returns>The hash code.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Object)">
+            <summary>
+            Returns a boolean indicating whether the given Object is equal to this Vector4 instance.
+            </summary>
+            <param name="obj">The Object to compare against.</param>
+            <returns>True if the Object is equal to this Vector4; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString">
+            <summary>
+            Returns a String representing this Vector4 instance.
+            </summary>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a String representing this Vector4 instance, using the specified format to format individual elements 
+            and the given IFormatProvider.
+            </summary>
+            <param name="format">The format of individual elements.</param>
+            <param name="formatProvider">The format provider to use when formatting elements.</param>
+            <returns>The string representation.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Length">
+            <summary>
+            Returns the length of the vector. This operation is cheaper than Length().
+            </summary>
+            <returns>The vector's length.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.LengthSquared">
+            <summary>
+            Returns the length of the vector squared.
+            </summary>
+            <returns>The vector's length squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Distance(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.DistanceSquared(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the Euclidean distance squared between the two given points.
+            </summary>
+            <param name="value1">The first point.</param>
+            <param name="value2">The second point.</param>
+            <returns>The distance squared.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Normalize(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector with the same direction as the given vector, but with a length of 1.
+            </summary>
+            <param name="vector">The vector to normalize.</param>
+            <returns>The normalized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Clamp(System.Numerics.Vector4,System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Restricts a vector between a min and max value.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="min">The minimum value.</param>
+            <param name="max">The maximum value.</param>
+            <returns>The restricted vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Lerp(System.Numerics.Vector4,System.Numerics.Vector4,System.Single)">
+            <summary>
+            Linearly interpolates between two vectors based on the given weighting.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of the second source vector.</param>
+            <returns>The interpolated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="position">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Matrix4x4)">
+            <summary>
+            Transforms a vector by the given matrix.
+            </summary>
+            <param name="vector">The source vector.</param>
+            <param name="matrix">The transformation matrix.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector2,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector3,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Transform(System.Numerics.Vector4,System.Numerics.Quaternion)">
+            <summary>
+            Transforms a vector by the given Quaternion rotation value.
+            </summary>
+            <param name="value">The source vector to be rotated.</param>
+            <param name="rotation">The rotation to apply.</param>
+            <returns>The transformed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Add(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Subtract(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Divide(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="divisor">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Negate(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="F:System.Numerics.Vector4.X">
+            <summary>
+            The X component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Y">
+            <summary>
+            The Y component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.Z">
+            <summary>
+            The Z component of the vector.
+            </summary>
+        </member>
+        <member name="F:System.Numerics.Vector4.W">
+            <summary>
+            The W component of the vector.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single)">
+            <summary>
+            Constructs a vector whose elements are all the single specified value.
+            </summary>
+            <param name="value">The element to fill the vector with.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Constructs a vector with the given individual elements.
+            </summary>
+            <param name="w">W component.</param>
+            <param name="x">X component.</param>
+            <param name="y">Y component.</param>
+            <param name="z">Z component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector2,System.Single,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector2 and a Z and W component.
+            </summary>
+            <param name="value">The vector to use as the X and Y components.</param>
+            <param name="z">The Z component.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.#ctor(System.Numerics.Vector3,System.Single)">
+            <summary>
+            Constructs a Vector4 from the given Vector3 and a W component.
+            </summary>
+            <param name="value">The vector to use as the X, Y, and Z components.</param>
+            <param name="w">The W component.</param>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[])">
+            <summary>
+            Copies the contents of the vector into the given array.
+            </summary>
+        </member>
+        <member name="M:System.Numerics.Vector4.CopyTo(System.Single[],System.Int32)">
+            <summary>
+            Copies the contents of the vector into the given array, starting from index.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If array is null.</exception>
+            <exception cref="T:System.RankException">If array is multidimensional.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero.</exception>
+            <exception cref="T:System.ArgumentException">If number of elements in source vector is greater than those available in destination array.</exception>
+        </member>
+        <member name="M:System.Numerics.Vector4.Equals(System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the given Vector4 is equal to this Vector4 instance.
+            </summary>
+            <param name="other">The Vector4 to compare this instance to.</param>
+            <returns>True if the other Vector4 is equal to this instance; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Dot(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns the dot product of two vectors.
+            </summary>
+            <param name="vector1">The first vector.</param>
+            <param name="vector2">The second vector.</param>
+            <returns>The dot product.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Min(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the minimum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The minimized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Max(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the maximum of each of the pairs of elements in the two source vectors.
+            </summary>
+            <param name="value1">The first source vector.</param>
+            <param name="value2">The second source vector.</param>
+            <returns>The maximized vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.Abs(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the absolute values of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The absolute value vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.SquareRoot(System.Numerics.Vector4)">
+            <summary>
+            Returns a vector whose elements are the square root of each of the source vector's elements.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The square root vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Addition(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Adds two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The summed vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Subtraction(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Subtracts the second vector from the first.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The difference vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Multiplies two vectors together.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The product vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The source vector.</param>
+            <param name="right">The scalar value.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Multiply(System.Single,System.Numerics.Vector4)">
+            <summary>
+            Multiplies a vector by the given scalar.
+            </summary>
+            <param name="left">The scalar value.</param>
+            <param name="right">The source vector.</param>
+            <returns>The scaled vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Divides the first vector by the second.
+            </summary>
+            <param name="left">The first source vector.</param>
+            <param name="right">The second source vector.</param>
+            <returns>The vector resulting from the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Division(System.Numerics.Vector4,System.Single)">
+            <summary>
+            Divides the vector by the given scalar.
+            </summary>
+            <param name="value1">The source vector.</param>
+            <param name="value2">The scalar value.</param>
+            <returns>The result of the division.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_UnaryNegation(System.Numerics.Vector4)">
+            <summary>
+            Negates a given vector.
+            </summary>
+            <param name="value">The source vector.</param>
+            <returns>The negated vector.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Equality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are equal; False otherwise.</returns>
+        </member>
+        <member name="M:System.Numerics.Vector4.op_Inequality(System.Numerics.Vector4,System.Numerics.Vector4)">
+            <summary>
+            Returns a boolean indicating whether the two given vectors are not equal.
+            </summary>
+            <param name="left">The first vector to compare.</param>
+            <param name="right">The second vector to compare.</param>
+            <returns>True if the vectors are not equal; False if they are equal.</returns>
+        </member>
+        <member name="P:System.SR.Arg_ArgumentOutOfRangeException">
+            <summary>Index was out of bounds:</summary>
+        </member>
+        <member name="P:System.SR.Arg_ElementsInSourceIsGreaterThanDestination">
+            <summary>Number of elements in source vector is greater than the destination array</summary>
+        </member>
+        <member name="P:System.SR.Arg_NullArgumentNullRef">
+            <summary>The method was called with a null array argument.</summary>
+        </member>
+        <member name="P:System.SR.Arg_TypeNotSupported">
+            <summary>Specified type is not supported</summary>
+        </member>
+        <member name="P:System.SR.Arg_InsufficientNumberOfElements">
+            <summary>At least {0} element(s) are expected in the parameter "{1}".</summary>
+        </member>
+    </members>
 </doc>


### PR DESCRIPTION
Shares the BSA and BAC metadata the editors need, labels each move file by type for the editor tabs, and shows real file names in the selectors instead of raw indices. Backs the XenoKit BSA editor work.